### PR TITLE
feat: add unicode support

### DIFF
--- a/src/internal/combinators/string.ts
+++ b/src/internal/combinators/string.ts
@@ -1,17 +1,42 @@
 import { success, failure, State, Parser } from '../state'
+import { size } from '../unicode'
 
 export function string(match: string): Parser<string> {
   return {
     parse(state: State) {
-      const endIndex = state.index + match.length
+      const index = state.index + match.length
+      const slice = state.text.substring(state.index, index)
 
-      if (state.text.substring(state.index, endIndex) === match) {
-        return success({ text: state.text, index: endIndex }, match)
-      } else {
-        return failure(state, match)
+      switch (slice === match) {
+        case true: {
+          return success({ text: state.text, index }, match)
+        }
+
+        case false: {
+          return failure(state, match)
+        }
       }
     }
   }
 }
 
-export { string as str }
+export function uniString(match: string): Parser<string> {
+  return {
+    parse(state: State) {
+      const index = state.index + size(match)
+      const slice = state.text.substring(state.index, index)
+
+      switch (slice === match) {
+        case true: {
+          return success({ text: state.text, index }, match)
+        }
+
+        case false: {
+          return failure(state, match)
+        }
+      }
+    }
+  }
+}
+
+export { string as str, uniString as ustr }

--- a/src/internal/unicode.ts
+++ b/src/internal/unicode.ts
@@ -1,0 +1,61 @@
+/**
+ * Iterates over a given Unicode string and counts its length in bytes.
+ *
+ * Covers Basic Multilingual Plane with all 163 blocks in range from `0x0000` to `0xFFFF`.
+ */
+export function size(string: string): number {
+  const size = string.length
+  let bytes = 0
+
+  for (let index = 0; index < size; index++) {
+    const high = string.charCodeAt(index)
+
+    switch (true) {
+      // [0x0000, 0x007F] - [Basic Latin]
+      case high < 0x0080: {
+        bytes += 1
+        break
+      }
+
+      // [0x0080, 0x07FF] - [Latin-1 Supplement, NKo]
+      case high < 0x0800: {
+        bytes += 2
+        break
+      }
+
+      // [0x0800, 0xD7FF] - [Samaritan, Hangul Jamo Extended-B]
+      case high < 0xd800: {
+        bytes += 3
+        break
+      }
+
+      // [0xD800, 0xDBFF] - [High Surrogates, High Private Use Surrogates]
+      case high < 0xdc00: {
+        // Stepping into low surrogates territory. Here we should be using **two** code points.
+        const low = string.charCodeAt(++index)
+
+        // Followed by: [0xDC00, 0xDFFF] - [Low Surrogates]
+        if (index < size && low >= 0xdc00 && low <= 0xdfff) {
+          bytes += 4
+          break
+        } else {
+          throw new Error('Malformed Unicode string with missing or invalid low surrogate.')
+        }
+      }
+
+      // [0xDC00, 0xDFFF] - [Low Surrogates], but if we somehow get here, then the string is
+      // malformed, because here we get only **one** code point.
+      case high < 0xe000: {
+        throw new Error('Malformed Unicode string with invalid high surrogate.')
+      }
+
+      // [0xE000, 0xFFFF] - [Private Use Area, Specials]
+      default: {
+        bytes += 3
+        break
+      }
+    }
+  }
+
+  return bytes
+}

--- a/tests/internal/combinators/regexp.spec.ts
+++ b/tests/internal/combinators/regexp.spec.ts
@@ -4,7 +4,7 @@ import { regexp } from '@lib/combinators'
 import { run, result, should } from '@tests/@setup/jest.helpers'
 
 describe('internal/combinators/regexp', () => {
-  it(`should expose 'regexp' w/ 're' alias`, () => {
+  it(`should expose 'regexp' ('re')`, () => {
     should.expose(exposed, 'regexp', 're')
   })
 
@@ -22,6 +22,24 @@ describe('internal/combinators/regexp', () => {
       should.matchState(actualDigit, expectedDigit)
       should.matchState(actualDigits, expectedDigits)
       should.matchState(actualMatchGroups, expectedMatchGroups)
+    })
+
+    it(`should properly work with unicode flag`, () => {
+      const actualReEmoji = run(regexp(/\w+\s+👌/gu, 'words, spaces, ok emoji'), 'Yes 👌')
+      const expectedReEmoji = result('success', 'Yes 👌')
+
+      should.matchState(actualReEmoji, expectedReEmoji)
+    })
+
+    it(`should properly work with unicode property escapes`, () => {
+      const actualReEmoji = run(regexp(/\p{Emoji_Presentation}+/gu, 'emoji'), '👌👌👌')
+      const expectedReEmoji = result('success', '👌👌👌')
+
+      const actualReNonLatin = run(regexp(/\P{Script_Extensions=Latin}+/gu, 'non-latin'), '大阪')
+      const expectedReNonLation = result('success', '大阪')
+
+      should.matchState(actualReEmoji, expectedReEmoji)
+      should.matchState(actualReNonLatin, expectedReNonLation)
     })
 
     it(`should succeeed if matches the beginning of the input`, () => {
@@ -49,7 +67,7 @@ describe('internal/combinators/regexp', () => {
       should.matchState(actualZeroFailure, expectedZeroFailure)
     })
 
-    // TODO: Though this is kinda contrintuitive, so maybe should throw/fail?
+    // TODO: Though this is kinda counterintuitive, so maybe should throw/fail?
     it(`should succeed if given zero input and regexp with 'zero or more' quantifier`, () => {
       const actualZeroSuccess = run(regexp(/\d*/g, 'digits*'), '')
       const expectedZeroSuccess = result('success', '')

--- a/tests/internal/combinators/string.spec.ts
+++ b/tests/internal/combinators/string.spec.ts
@@ -27,6 +27,27 @@ describe('internal/combinators/string', () => {
       should.matchState(actualUniUmlauts, expectedUniUmlauts)
       should.matchState(actualUniEmojis, expectedUniEmojis)
     })
+
+    it(`should succeed if given repetitive input`, () => {
+      const actual = run(uniString('test'), 'testtest')
+      const expected = result('success', 'test')
+
+      should.matchState(actual, expected)
+    })
+
+    it(`should fail if doesn't match the input`, () => {
+      const actual = run(uniString('test'), 'wrong')
+      const expected = result('failure', 'test')
+
+      should.matchState(actual, expected)
+    })
+
+    it(`should fail if given zero input`, () => {
+      const actual = run(uniString('test'), '')
+      const expected = result('failure', 'test')
+
+      should.matchState(actual, expected)
+    })
   })
 
   describe(string, () => {

--- a/tests/internal/combinators/string.spec.ts
+++ b/tests/internal/combinators/string.spec.ts
@@ -1,45 +1,59 @@
 import * as exposed from '@lib/combinators'
-import { string } from '@lib/combinators'
+import { string, uniString } from '@lib/combinators'
 
 import { run, result, should } from '@tests/@setup/jest.helpers'
 
 describe('internal/combinators/string', () => {
-  it(`should expose 'string' ('str')`, () => {
-    should.expose(exposed, 'string', 'str')
+  it(`should expose 'string' ('str') and 'uniString' ('ustr')`, () => {
+    should.expose(exposed, 'string', 'str', 'uniString', 'ustr')
+  })
+
+  describe(uniString, () => {
+    it(`should succeed if matches the input`, () => {
+      const actualAscii = run(uniString('test'), 'test')
+      const expectedAscii = result('success', 'test')
+
+      const actualUniChinese = run(uniString('语言处理'), '语言处理')
+      const expectedUniChinese = result('success', '语言处理')
+
+      const actualUniUmlauts = run(uniString('Hëllø!'), 'Hëllø!')
+      const expectedUniUmlauts = result('success', 'Hëllø!')
+
+      const actualUniEmojis = run(uniString('Family :: 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦'), 'Family :: 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦')
+      const expectedUniEmojis = result('success', 'Family :: 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦')
+
+      should.matchState(actualAscii, expectedAscii)
+      should.matchState(actualUniChinese, expectedUniChinese)
+      should.matchState(actualUniUmlauts, expectedUniUmlauts)
+      should.matchState(actualUniEmojis, expectedUniEmojis)
+    })
   })
 
   describe(string, () => {
-    const ok = 'test'
-    const err = 'text'
-    const repetitive = 'testtest'
-    const zero = ''
-
-    const parser = string(ok)
-
     it(`should succeed if matches the input`, () => {
-      const actual = run(parser, ok)
-      const expected = result('success', ok)
+      const actual = run(string('test'), 'test')
+      const expected = result('success', 'test')
 
       should.matchState(actual, expected)
     })
 
     it(`should succeed if given repetitive input`, () => {
-      const actual = run(parser, repetitive)
-      const expected = result('success', ok)
+      const actual = run(string('test'), 'testtest')
+      const expected = result('success', 'test')
 
       should.matchState(actual, expected)
     })
 
     it(`should fail if doesn't match the input`, () => {
-      const actual = run(parser, err)
-      const expected = result('failure', ok)
+      const actual = run(string('test'), 'wrong')
+      const expected = result('failure', 'test')
 
       should.matchState(actual, expected)
     })
 
     it(`should fail if given zero input`, () => {
-      const actual = run(parser, zero)
-      const expected = result('failure', ok)
+      const actual = run(string('test'), '')
+      const expected = result('failure', 'test')
 
       should.matchState(actual, expected)
     })

--- a/tests/internal/unicode.data.ts
+++ b/tests/internal/unicode.data.ts
@@ -1,0 +1,114 @@
+interface Pangram {
+  readonly text: string
+  readonly size: number
+}
+
+export const pangrams: Record<string, Pangram | Array<Pangram>> = {
+  // Danish
+  da: {
+    text: `Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen Wolther spillede på xylofon`,
+    size: 90
+  },
+
+  // English
+  en: {
+    text: `The quick brown fox jumps over the lazy dog`,
+    size: 43
+  },
+
+  // French
+  fr: [
+    {
+      text: `Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogenèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre`,
+      size: 349
+    },
+    {
+      text: `l'île exiguë Où l'obèse jury mûr Fête l'haï volapük, Âne ex aéquo au whist, Ôtez ce vœu déçu`,
+      size: 106
+    },
+    {
+      text: `Le cœur déçu mais l'âme plutôt naïve, Louÿs rêva de crapaüter en canoë au delà des îles, près du mälström où brûlent les novæ`,
+      size: 143
+    }
+  ],
+
+  // German
+  de: [
+    {
+      text: `Falsches Üben von Xylophonmusik quält jeden größeren Zwerg`,
+      size: 62
+    },
+    {
+      text: `Zwölf Boxkämpfer jagten Eva quer über den Sylter Deich`,
+      size: 57
+    },
+    {
+      text: `Heizölrückstoßabdämpfung`,
+      size: 28
+    }
+  ],
+
+  // Hebrew
+  iw: {
+    text: `דג סקרן שט בים מאוכזב ולפתע מצא לו חברה איך הקליטה`,
+    size: 90
+  },
+
+  // Hungarian
+  hu: {
+    text: `Árvíztűrő tükörfúrógép`,
+    size: 31
+  },
+
+  // Icelandic
+  is: [
+    {
+      text: `Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa`,
+      size: 61
+    },
+    {
+      text: `Sævör grét áðan því úlpan var ónýt`,
+      size: 44
+    }
+  ],
+
+  // Irish Gaelic
+  ga: {
+    text: `D'fhuascail Íosa, Úrmhac na hÓighe Beannaithe, pór Éava agus Ádhaimh`,
+    size: 74
+  },
+
+  // Japanese
+  ja: [
+    {
+      text: `いろはにほへとちりぬるを
+わかよたれそつねならむ
+うゐのおくやまけふこえて
+あさきゆめみしゑひもせす`,
+      size: 144
+    },
+    {
+      text: `イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム
+ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン`,
+      size: 151
+    }
+  ],
+
+  // Polish
+  pl: {
+    text: `Pchnąć w tę łódź jeża lub ośm skrzyń fig`,
+    size: 49
+  },
+
+  // Russian
+  ru: {
+    text: `В чащах юга жил бы цитрус? Да, но фальшивый экземпляр!`,
+    size: 96
+  },
+
+  // Spanish
+  es: {
+    text: `El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro`,
+    size: 102
+  }
+}

--- a/tests/internal/unicode.spec.ts
+++ b/tests/internal/unicode.spec.ts
@@ -10,7 +10,7 @@ describe(size, () => {
       : expect(size(pangram.text)).toBe(pangram.size)
   }
 
-  it('should correctly count size of unicode pangrams in bytes', () => {
+  it('should correctly get length of unicode pangrams in bytes', () => {
     check('da')
     check('en')
     check('fr')
@@ -25,11 +25,30 @@ describe(size, () => {
     check('es')
   })
 
-  it('should correctly count size of emoji in bytes', () => {
+  it('should correctly get length of emojis in bytes', () => {
     expect(size(`⚡`)).toBe(3)
     expect(size(`🦶🏿`)).toBe(8)
     expect(size(`👨‍👨‍👧‍👧`)).toBe(25)
     expect(size(`🏴󠁧󠁢󠁥󠁮󠁧󠁿`)).toBe(28)
+  })
+
+  it('should correctly calculate length of any char in bytes in range [E000, FFFF]', () => {
+    ;[
+      '\uE000', // Private Use Area
+      '\uF900', // CJK Compatibility Ideographs
+      '\uFB00', // Alphabetic Presentation Forms
+      '\uFB50', // Arabic Presentation Forms
+      '\uFE00', // Variation Selectors
+      '\uFE10', // Vertical Forms
+      '\uFE20', // Combining Half Marks
+      '\uFE30', // CJK Compatibility Forms
+      '\uFE50', // Small Form Variants
+      '\uFE70', // Arabic Presentation Forms-B
+      '\uFF00', // Half-Width and Fullwidth Forms
+      '\uFFF0' // Specials
+    ].forEach((char) => {
+      expect(size(char)).toBe(3)
+    })
   })
 
   it('should throw if provided with invalid single surrogates', () => {
@@ -41,8 +60,8 @@ describe(size, () => {
       '\uDC00', // Invalid high surrogate
       '\uDF80', // Invalid high surrogate
       '\uDFFF' // Invalid high surrogate
-    ].forEach((single) => {
-      expect(() => size(single)).toThrow()
+    ].forEach((char) => {
+      expect(() => size(char)).toThrow()
     })
   })
 })

--- a/tests/internal/unicode.spec.ts
+++ b/tests/internal/unicode.spec.ts
@@ -1,0 +1,48 @@
+import { size } from '@lib/internal/unicode'
+import { pangrams } from './unicode.data'
+
+describe(size, () => {
+  function check(locale: string) {
+    const pangram = pangrams[locale]
+
+    return Array.isArray(pangram)
+      ? pangram.forEach((data) => expect(size(data.text)).toBe(data.size))
+      : expect(size(pangram.text)).toBe(pangram.size)
+  }
+
+  it('should correctly count size of unicode pangrams in bytes', () => {
+    check('da')
+    check('en')
+    check('fr')
+    check('de')
+    check('iw')
+    check('hu')
+    check('is')
+    check('ga')
+    check('ja')
+    check('pl')
+    check('ru')
+    check('es')
+  })
+
+  it('should correctly count size of emoji in bytes', () => {
+    expect(size(`⚡`)).toBe(3)
+    expect(size(`🦶🏿`)).toBe(8)
+    expect(size(`👨‍👨‍👧‍👧`)).toBe(25)
+    expect(size(`🏴󠁧󠁢󠁥󠁮󠁧󠁿`)).toBe(28)
+  })
+
+  it('should throw if provided with invalid single surrogates', () => {
+    ;[
+      '\uD800', // Missing low surrogate
+      '\uDB7F', // Missing low surrogate
+      '\uDB80', // Missing low surrogate
+      '\uDBFF', // Missing low surrogate
+      '\uDC00', // Invalid high surrogate
+      '\uDF80', // Invalid high surrogate
+      '\uDFFF' // Invalid high surrogate
+    ].forEach((single) => {
+      expect(() => size(single)).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Basic and somewhat hacky Unicode support in the form of a new `uniString` combinator.

> The `regexp` combinator should support Unicode out-of-the-box with `u` flag.

#### How it works
I figured we only really need to get the correct matching string length (in bytes, hence that `size` utility function), so we can properly increment `index`. Surprisingly, it worked very well so far and synthetic benchmarks showed that unicode equivalent of `string` combinator is only 2-3 times slower, whereas other implementations I tried, namely `TextEncoder`/`TextDecoder` + `DataView` (which is what **arcsecond** uses) is _orders of magnitude_ slower, though "bulletproof", I guess.

#### Limitations
Because of how the `size` function is implemented, it supports only the [Basic Multilingual Plane](https://unicode.org/roadmaps/bmp/). Should be enough, I hope.

Resolves #3 