### PR TITLE
Tests: Improve grouping with describe helper, small QoL changes to testing

### DIFF
--- a/src/__tests__/@helpers/index.ts
+++ b/src/__tests__/@helpers/index.ts
@@ -1,3 +1,4 @@
+import { type Context, suite, uvu } from 'uvu'
 import * as assert from 'uvu/assert'
 
 import { run as internal$run } from '../../parsers/run'
@@ -14,6 +15,12 @@ export function run<T>(parser: Parser<T>, text: string): Result<T> {
 
 export function result<T>(isOk: boolean, value: T): ReducedResult<T> {
   return { isOk, value } as const
+}
+
+export function describe<T = Context>(name: string, f: (t: uvu.Test<T>) => void | Promise<void>) {
+  const test = suite<T>(name)
+  f(test)
+  test.run()
 }
 
 export const should = {
@@ -33,6 +40,14 @@ export const should = {
         return assert.equal(received.expected, expected.value)
       }
     }
+  },
+
+  beEqual<T = unknown>(a: T, b: T, message?: string) {
+    assert.equal(a, b, message)
+  },
+
+  throw(f: typeof assert.throws) {
+    assert.throws(f)
   }
 }
 

--- a/src/__tests__/combinators/chain.spec.ts
+++ b/src/__tests__/combinators/chain.spec.ts
@@ -1,11 +1,9 @@
-import { suite } from 'uvu'
-
 import { chainl } from '../../combinators/chain'
 import { map } from '../../combinators/map'
 import { takeRight } from '../../combinators/take'
 import { regexp } from '../../parsers/regexp'
 import { string } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
 const toSum = (left: number, right: number) => left + right
 const toNumber = (value: string) => parseInt(value, 10)
@@ -13,20 +11,18 @@ const toNumber = (value: string) => parseInt(value, 10)
 const number = map(regexp(/\d+/g, 'integer'), toNumber)
 const parser = chainl(number, takeRight(string(' + '), number), toSum)
 
-const it = suite('chain')
+describe('chain', (it) => {
+  it('should succeed with eliminated left recursion and reduced to a value', () => {
+    const actual = run(parser, '2 + 2 + 4')
+    const expected = result(true, 8)
 
-it('should succeed with eliminated left recursion and reduced to a value', () => {
-  const actual = run(parser, '2 + 2 + 4')
-  const expected = result(true, 8)
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail with expectation of the regexp parser', () => {
+    const actual = run(parser, 'x + x + 4')
+    const expected = result(false, 'integer')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should fail with expectation of the regexp parser', () => {
-  const actual = run(parser, 'x + x + 4')
-  const expected = result(false, 'integer')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/choice.spec.ts
+++ b/src/__tests__/combinators/choice.spec.ts
@@ -1,25 +1,21 @@
-import { suite } from 'uvu'
-
 import { choice } from '../../combinators/choice'
 import { string } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
-const it = suite('choice')
+describe('choice', (it) => {
+  it('should succeed with the value of the first successful parser in sequence', () => {
+    const parser = choice(string('left'), string('mid'), string('right'))
+    const actual = run(parser, 'mid')
+    const expected = result(true, 'mid')
 
-it('should succeed with the value of the first successful parser in sequence', () => {
-  const parser = choice(string('left'), string('mid'), string('right'))
-  const actual = run(parser, 'mid')
-  const expected = result(true, 'mid')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail with the expectation of the last parser in sequence', () => {
+    const parser = choice(string('left'), string('mid'), string('right'))
+    const actual = run(parser, 'between')
+    const expected = result(false, 'right')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should fail with the expectation of the last parser in sequence', () => {
-  const parser = choice(string('left'), string('mid'), string('right'))
-  const actual = run(parser, 'between')
-  const expected = result(false, 'right')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/error.spec.ts
+++ b/src/__tests__/combinators/error.spec.ts
@@ -1,25 +1,21 @@
-import { suite } from 'uvu'
-
 import { error } from '../../combinators/error'
 import { string } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
-const it = suite('error')
+describe('error', (it) => {
+  it('should successfully replace error message (expectation)', () => {
+    const parser = error(string('9000'), 'replaced-error-message')
+    const actual = run(parser, 'xxxx')
+    const expected = result(false, 'replaced-error-message')
 
-it('should successfully replace error message (expectation)', () => {
-  const parser = error(string('9000'), 'replaced-error-message')
-  const actual = run(parser, 'xxxx')
-  const expected = result(false, 'replaced-error-message')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should not do anything if a parser succeeds', () => {
+    const parser = error(string('9000'), 'replaced-error-message')
+    const actual = run(parser, '9000')
+    const expected = result(true, '9000')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should not do anything if a parser succeeds', () => {
-  const parser = error(string('9000'), 'replaced-error-message')
-  const actual = run(parser, '9000')
-  const expected = result(true, '9000')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/many.spec.ts
+++ b/src/__tests__/combinators/many.spec.ts
@@ -1,49 +1,42 @@
-import { suite } from 'uvu'
-
 import { many, many1 } from '../../combinators/many'
 import { string } from '../../parsers/string'
-import { result, run, should, testFailure } from '../@helpers'
+import { describe, result, run, should, testFailure } from '../@helpers'
 
-let it = suite('many')
+describe('many', (it) => {
+  it('should succeed with an array of matched strings', () => {
+    const parser = many(string('x!'))
+    const actual = run(parser, 'x!x!x!')
+    const expected = result(true, ['x!', 'x!', 'x!'])
 
-it('should succeed with an array of matched strings', () => {
-  const parser = many(string('x!'))
-  const actual = run(parser, 'x!x!x!')
-  const expected = result(true, ['x!', 'x!', 'x!'])
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should succeed with an empty array even if nothing matched', () => {
+    const parser = many(string('hello'))
+    const actual = run(parser, 'byebye')
+    const expected = result(true, [])
+
+    should.matchState(actual, expected)
+  })
 })
+describe('many1', (it) => {
+  it('should succeed with an array of matched strings', () => {
+    const parser = many1(string('x!'))
+    const actual = run(parser, 'x!x!x!')
+    const expected = result(true, ['x!', 'x!', 'x!'])
 
-it('should succeed with an empty array even if nothing matched', () => {
-  const parser = many(string('hello'))
-  const actual = run(parser, 'byebye')
-  const expected = result(true, [])
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail if nothing matched', () => {
+    testFailure('y!y!y!', many1(string('x!')))
+  })
+
+  it('should fail with the expectation of the parser', () => {
+    const parser = many1(string('x!'))
+    const actual = run(parser, 'a!b!c!')
+    const expected = result(false, 'x!')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it.run()
-
-it = suite('many1')
-
-it('should succeed with an array of matched strings', () => {
-  const parser = many1(string('x!'))
-  const actual = run(parser, 'x!x!x!')
-  const expected = result(true, ['x!', 'x!', 'x!'])
-
-  should.matchState(actual, expected)
-})
-
-it('should fail if nothing matched', () => {
-  testFailure('y!y!y!', many1(string('x!')))
-})
-
-it('should fail with the expectation of the parser', () => {
-  const parser = many1(string('x!'))
-  const actual = run(parser, 'a!b!c!')
-  const expected = result(false, 'x!')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/map.spec.ts
+++ b/src/__tests__/combinators/map.spec.ts
@@ -1,37 +1,31 @@
-import { suite } from 'uvu'
-
 import { map, mapTo } from '../../combinators/map'
 import { string } from '../../parsers/string'
-import { result, run, should } from '../@helpers'
+import { describe, result, run, should } from '../@helpers'
 
-let it = suite('map')
+describe('map', (it) => {
+  it('should succeed if a single given parser succeeds', () => {
+    const parser = map(string('9000'), (value) => parseInt(value, 10))
+    const actual = run(parser, '9000')
+    const expected = result(true, 9000)
 
-it('should succeed if a single given parser succeeds', () => {
-  const parser = map(string('9000'), (value) => parseInt(value, 10))
-  const actual = run(parser, '9000')
-  const expected = result(true, 9000)
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail if a single given parser fails', () => {
+    const parser = map(string('9000'), (value) => parseInt(value, 10))
+    const actual = run(parser, 'xxxx')
+    const expected = result(false, '9000')
+
+    should.matchState(actual, expected)
+  })
 })
 
-it('should fail if a single given parser fails', () => {
-  const parser = map(string('9000'), (value) => parseInt(value, 10))
-  const actual = run(parser, 'xxxx')
-  const expected = result(false, '9000')
+describe('mapTo', (it) => {
+  it('should succeed if a single given parser succeeds', () => {
+    const parser = mapTo(string('9000'), 'constant')
+    const actual = run(parser, '9000')
+    const expected = result(true, 'constant')
 
-  should.matchState(actual, expected)
+    should.matchState(actual, expected)
+  })
 })
-
-it.run()
-
-it = suite('mapTo')
-
-it('should succeed if a single given parser succeeds', () => {
-  const parser = mapTo(string('9000'), 'constant')
-  const actual = run(parser, '9000')
-  const expected = result(true, 'constant')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/optional.spec.ts
+++ b/src/__tests__/combinators/optional.spec.ts
@@ -1,26 +1,22 @@
-import { suite } from 'uvu'
-
 import { optional } from '../../combinators/optional'
 import { sequence } from '../../combinators/sequence'
 import { string } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
-const it = suite('optional')
+describe('optional', (it) => {
+  it('should succeed with the where optional non-matched value replaced with null', () => {
+    const parser = sequence(string('Hello'), optional(string('...')))
+    const actual = run(parser, 'Hello')
+    const expected = result(true, ['Hello', null])
 
-it('should succeed with the where optional non-matched value replaced with null', () => {
-  const parser = sequence(string('Hello'), optional(string('...')))
-  const actual = run(parser, 'Hello')
-  const expected = result(true, ['Hello', null])
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should succeed with null anyway', () => {
+    const parser = optional(string('left'))
+    const actual = run(parser, 'between')
+    const expected = result(true, null)
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should succeed with null anyway', () => {
-  const parser = optional(string('left'))
-  const actual = run(parser, 'between')
-  const expected = result(true, null)
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/sepBy.spec.ts
+++ b/src/__tests__/combinators/sepBy.spec.ts
@@ -1,33 +1,29 @@
-import { suite } from 'uvu'
-
 import { sepBy } from '../../combinators/sepBy'
 import { string } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
-const it = suite('sepBy')
+describe('sepBy', (it) => {
+  it('should succeed with an array of matched strings without separator', () => {
+    const parser = sepBy(string('x'), string('!'))
+    const actual = run(parser, 'x!x!x!')
+    const expected = result(true, ['x', 'x', 'x'])
 
-it('should succeed with an array of matched strings without separator', () => {
-  const parser = sepBy(string('x'), string('!'))
-  const actual = run(parser, 'x!x!x!')
-  const expected = result(true, ['x', 'x', 'x'])
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it(`should succeed with an array of matched string if separator didn't match`, () => {
+    const parser = sepBy(string('x'), string('!'))
+    const actual = run(parser, 'x-y')
+    const expected = result(true, ['x'])
+
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed with an empty array if nothing matched', () => {
+    const parser = sepBy(string('hello'), string('?'))
+    const actual = run(parser, 'bye?bye?')
+    const expected = result(true, [])
+
+    should.matchState(actual, expected)
+  })
 })
-
-it(`should succeed with an array of matched string if separator didn't match`, () => {
-  const parser = sepBy(string('x'), string('!'))
-  const actual = run(parser, 'x-y')
-  const expected = result(true, ['x'])
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed with an empty array if nothing matched', () => {
-  const parser = sepBy(string('hello'), string('?'))
-  const actual = run(parser, 'bye?bye?')
-  const expected = result(true, [])
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/sequence.spec.ts
+++ b/src/__tests__/combinators/sequence.spec.ts
@@ -1,25 +1,21 @@
-import { suite } from 'uvu'
-
 import { sequence } from '../../combinators/sequence'
 import { string } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
-const it = suite('sequence')
+describe('sequence', (it) => {
+  it('should succeed if a sequence of parsers succeeds', () => {
+    const parser = sequence(string('hello'), string(' '), string('world'))
+    const actual = run(parser, 'hello world')
+    const expected = result(true, ['hello', ' ', 'world'])
 
-it('should succeed if a sequence of parsers succeeds', () => {
-  const parser = sequence(string('hello'), string(' '), string('world'))
-  const actual = run(parser, 'hello world')
-  const expected = result(true, ['hello', ' ', 'world'])
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail if a sequence of parsers fails somewhere', () => {
+    const parser = sequence(string('hello'), string(' '), string('world'))
+    const actual = run(parser, 'bye friend')
+    const expected = result(false, 'hello')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should fail if a sequence of parsers fails somewhere', () => {
-  const parser = sequence(string('hello'), string(' '), string('world'))
-  const actual = run(parser, 'bye friend')
-  const expected = result(false, 'hello')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/take.spec.ts
+++ b/src/__tests__/combinators/take.spec.ts
@@ -1,85 +1,75 @@
-import { suite } from 'uvu'
-
 import { takeLeft, takeMid, takeRight, takeSides } from '../../combinators/take'
 import { string } from '../../parsers/string'
-import { result, run, should } from '../@helpers'
+import { describe, result, run, should } from '../@helpers'
 
-let it = suite('takeLeft')
+describe('takeLeft', (it) => {
+  it('should succeed with the value of the parser on the left-hand side', () => {
+    const parser = takeLeft(string('left'), string('mid'))
+    const actual = run(parser, 'leftmid')
+    const expected = result(true, 'left')
 
-it('should succeed with the value of the parser on the left-hand side', () => {
-  const parser = takeLeft(string('left'), string('mid'))
-  const actual = run(parser, 'leftmid')
-  const expected = result(true, 'left')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail completely when one of the parsers fail', () => {
+    const parser = takeLeft(string('left'), string('mid'))
+    const actual = run(parser, 'left mid')
+    const expected = result(false, 'mid')
+
+    should.matchState(actual, expected)
+  })
 })
 
-it('should fail completely when one of the parsers fail', () => {
-  const parser = takeLeft(string('left'), string('mid'))
-  const actual = run(parser, 'left mid')
-  const expected = result(false, 'mid')
+describe('takeMid', (it) => {
+  it('should succeed with the value of the parser in the middle', () => {
+    const parser = takeMid(string('left'), string('mid'), string('right'))
+    const actual = run(parser, 'leftmidright')
+    const expected = result(true, 'mid')
 
-  should.matchState(actual, expected)
+    should.matchState(actual, expected)
+  })
+
+  it('should fail completely when one of the parsers fail', () => {
+    const parser = takeMid(string('left'), string('mid'), string('right'))
+    const actual = run(parser, 'left midright')
+    const expected = result(false, 'mid')
+
+    should.matchState(actual, expected)
+  })
 })
 
-it.run()
+describe('takeRight', (it) => {
+  it('should succeed with the value of the parser on right-hand side', () => {
+    const parser = takeRight(string('mid'), string('right'))
+    const actual = run(parser, 'midright')
+    const expected = result(true, 'right')
 
-it = suite('takeMid')
+    should.matchState(actual, expected)
+  })
 
-it('should succeed with the value of the parser in the middle', () => {
-  const parser = takeMid(string('left'), string('mid'), string('right'))
-  const actual = run(parser, 'leftmidright')
-  const expected = result(true, 'mid')
+  it('should fail completely when one of the parsers fail', () => {
+    const parser = takeRight(string('mid'), string('right'))
+    const actual = run(parser, 'mid right')
+    const expected = result(false, 'right')
 
-  should.matchState(actual, expected)
+    should.matchState(actual, expected)
+  })
 })
 
-it('should fail completely when one of the parsers fail', () => {
-  const parser = takeMid(string('left'), string('mid'), string('right'))
-  const actual = run(parser, 'left midright')
-  const expected = result(false, 'mid')
+describe('takeSides', (it) => {
+  it('should succeed with the tuple of the first and the last values', () => {
+    const parser = takeSides(string('left'), string('mid'), string('right'))
+    const actual = run(parser, 'leftmidright')
+    const expected = result(true, ['left', 'right'])
 
-  should.matchState(actual, expected)
+    should.matchState(actual, expected)
+  })
+
+  it('should fail completely when one of the parsers fail', () => {
+    const parser = takeSides(string('left'), string('mid'), string('right'))
+    const actual = run(parser, 'left midright')
+    const expected = result(false, 'mid')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it.run()
-
-it = suite('takeRight')
-
-it('should succeed with the value of the parser on right-hand side', () => {
-  const parser = takeRight(string('mid'), string('right'))
-  const actual = run(parser, 'midright')
-  const expected = result(true, 'right')
-
-  should.matchState(actual, expected)
-})
-
-it('should fail completely when one of the parsers fail', () => {
-  const parser = takeRight(string('mid'), string('right'))
-  const actual = run(parser, 'mid right')
-  const expected = result(false, 'right')
-
-  should.matchState(actual, expected)
-})
-
-it.run()
-
-it = suite('takeSides')
-
-it('should succeed with the tuple of the first and the last values', () => {
-  const parser = takeSides(string('left'), string('mid'), string('right'))
-  const actual = run(parser, 'leftmidright')
-  const expected = result(true, ['left', 'right'])
-
-  should.matchState(actual, expected)
-})
-
-it('should fail completely when one of the parsers fail', () => {
-  const parser = takeSides(string('left'), string('mid'), string('right'))
-  const actual = run(parser, 'left midright')
-  const expected = result(false, 'mid')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/combinators/when.spec.ts
+++ b/src/__tests__/combinators/when.spec.ts
@@ -1,32 +1,28 @@
-import { suite } from 'uvu'
-
 import { when } from '../../combinators/when'
 import { string } from '../../parsers'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
 const parser = when(string('x'), () => string('y'))
 
-const it = suite('when')
+describe('when', (it) => {
+  it('should succeed with the value of chained parser', () => {
+    const actual = run(parser, 'xy')
+    const expected = result(true, 'y')
 
-it('should succeed with the value of chained parser', () => {
-  const actual = run(parser, 'xy')
-  const expected = result(true, 'y')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail with the expectation of context parser', () => {
+    const actual = run(parser, 'ab')
+    const expected = result(false, 'x')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail with the expectation of chained parser', () => {
+    const actual = run(parser, 'xw')
+    const expected = result(false, 'y')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should fail with the expectation of context parser', () => {
-  const actual = run(parser, 'ab')
-  const expected = result(false, 'x')
-
-  should.matchState(actual, expected)
-})
-
-it('should fail with the expectation of chained parser', () => {
-  const actual = run(parser, 'xw')
-  const expected = result(false, 'y')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/parsers/defer.spec.ts
+++ b/src/__tests__/parsers/defer.spec.ts
@@ -1,35 +1,31 @@
-import { suite } from 'uvu'
-
 import { defer } from '../../parsers/defer'
 import { string } from '../../parsers/string'
-import { run, result, should, testFailure } from '../@helpers'
+import { run, result, should, testFailure, describe } from '../@helpers'
 
-const it = suite('defer')
+describe('defer', (it) => {
+  it('should succeed if the deferred parser is not set', () => {
+    const deferred = defer<string>()
 
-it('should succeed if the deferred parser is not set', () => {
-  const deferred = defer<string>()
+    deferred.with(string('deferred'))
 
-  deferred.with(string('deferred'))
+    const actual = run(deferred, 'deferred')
+    const expected = result(true, 'deferred')
 
-  const actual = run(deferred, 'deferred')
-  const expected = result(true, 'deferred')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should throw if the deferred parser is not set', () => {
+    testFailure('deffered', defer<string>())
+  })
+
+  it('should fail if the deferred parser fails', () => {
+    const deferred = defer<string>()
+
+    deferred.with(string('deferred'))
+
+    const actual = run(deferred, 'lazy')
+    const expected = result(false, 'deferred')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should throw if the deferred parser is not set', () => {
-  testFailure('deffered', defer<string>())
-})
-
-it('should fail if the deferred parser fails', () => {
-  const deferred = defer<string>()
-
-  deferred.with(string('deferred'))
-
-  const actual = run(deferred, 'lazy')
-  const expected = result(false, 'deferred')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/parsers/eof.spec.ts
+++ b/src/__tests__/parsers/eof.spec.ts
@@ -1,26 +1,22 @@
-import { suite } from 'uvu'
-
 import { sequence } from '../../combinators/sequence'
 import { eof } from '../../parsers/eof'
 import { string } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
-const it = suite('eof')
+describe('eof', (it) => {
+  it('should succeed if reached the end of input', () => {
+    const parser = sequence(string('start'), eof())
+    const actual = run(parser, 'start')
+    const expected = result(true, ['start', null])
 
-it('should succeed if reached the end of input', () => {
-  const parser = sequence(string('start'), eof())
-  const actual = run(parser, 'start')
-  const expected = result(true, ['start', null])
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail if did not reach the end of input', () => {
+    const parser = sequence(string('start'), eof())
+    const actual = run(parser, 'start end')
+    const expected = result(false, 'end of input')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should fail if did not reach the end of input', () => {
-  const parser = sequence(string('start'), eof())
-  const actual = run(parser, 'start end')
-  const expected = result(false, 'end of input')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/parsers/eol.spec.ts
+++ b/src/__tests__/parsers/eol.spec.ts
@@ -1,48 +1,44 @@
-import { suite } from 'uvu'
-
 import { sequence } from '../../combinators/sequence'
 import { eol } from '../../parsers/eol'
 import { letters } from '../../parsers/letter'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
 const tcase = `Hello\nWorld\n`
 const tcaseLit = `Hello
 World
 `
 
-const it = suite('eol')
+describe('eol', (it) => {
+  it('should succeed if given a newline (Unix)', () => {
+    const actual = run(eol(), '\n')
+    const expected = result(true, '\n')
 
-it('should succeed if given a newline (Unix)', () => {
-  const actual = run(eol(), '\n')
-  const expected = result(true, '\n')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should succeed if given a newline sequence (non-Unix)', () => {
+    const actual = run(eol(), '\r\n')
+    const expected = result(true, '\r\n')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed if given a string with a newline at the end', () => {
+    const parser = sequence(letters(), eol(), letters(), eol())
+
+    const actualExplicit = run(parser, tcase)
+    const actualImplicit = run(parser, tcaseLit)
+
+    const expected = result(true, ['Hello', '\n', 'World', '\n'])
+
+    should.matchState(actualExplicit, expected)
+    should.matchState(actualImplicit, expected)
+  })
+
+  it('should fail if given a string without a newline', () => {
+    const actual = run(sequence(letters(), eol()), 'Hello')
+    const expected = result(false, 'end of line')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should succeed if given a newline sequence (non-Unix)', () => {
-  const actual = run(eol(), '\r\n')
-  const expected = result(true, '\r\n')
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed if given a string with a newline at the end', () => {
-  const parser = sequence(letters(), eol(), letters(), eol())
-
-  const actualExplicit = run(parser, tcase)
-  const actualImplicit = run(parser, tcaseLit)
-
-  const expected = result(true, ['Hello', '\n', 'World', '\n'])
-
-  should.matchState(actualExplicit, expected)
-  should.matchState(actualImplicit, expected)
-})
-
-it('should fail if given a string without a newline', () => {
-  const actual = run(sequence(letters(), eol()), 'Hello')
-  const expected = result(false, 'end of line')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/parsers/float.spec.ts
+++ b/src/__tests__/parsers/float.spec.ts
@@ -1,47 +1,43 @@
-import { suite } from 'uvu'
-
 import { float } from '../../parsers/float'
-import { testFailure, testSuccess } from '../@helpers'
+import { describe, testFailure, testSuccess } from '../@helpers'
 
-const it = suite('float')
+describe('float', (it) => {
+  it('should succeed if given a float', () => {
+    const tcases = [
+      ['20.99', 20.99],
+      ['-20.99', -20.99]
+    ] as const
 
-it('should succeed if given a float', () => {
-  const tcases = [
-    ['20.99', 20.99],
-    ['-20.99', -20.99]
-  ] as const
+    tcases.forEach(([input, value]) => {
+      testSuccess(input, value, float())
+    })
+  })
 
-  tcases.forEach(([input, value]) => {
-    testSuccess(input, value, float())
+  it('should fail if given an integer', () => {
+    ;['20', '2', '-20', '-2'].forEach((tcase) => {
+      testFailure(tcase, float())
+    })
+  })
+
+  it('should fail if given a float without a leading zero', () => {
+    testFailure('.99', float())
+  })
+
+  it('should fail if given an octal', () => {
+    testFailure('0o644', float())
+  })
+
+  it('should fail if given a binary', () => {
+    testFailure('0b100', float())
+  })
+
+  it('should fail if given a hexadecimal', () => {
+    testFailure('0xf00d', float())
+  })
+
+  it('should fail if given an exponential', () => {
+    ;['0e-5', '2e+3', '1e3'].forEach((tcase) => {
+      testFailure(tcase, float())
+    })
   })
 })
-
-it('should fail if given an integer', () => {
-  ;['20', '2', '-20', '-2'].forEach((tcase) => {
-    testFailure(tcase, float())
-  })
-})
-
-it('should fail if given a float without a leading zero', () => {
-  testFailure('.99', float())
-})
-
-it('should fail if given an octal', () => {
-  testFailure('0o644', float())
-})
-
-it('should fail if given a binary', () => {
-  testFailure('0b100', float())
-})
-
-it('should fail if given a hexadecimal', () => {
-  testFailure('0xf00d', float())
-})
-
-it('should fail if given an exponential', () => {
-  ;['0e-5', '2e+3', '1e3'].forEach((tcase) => {
-    testFailure(tcase, float())
-  })
-})
-
-it.run()

--- a/src/__tests__/parsers/integer.spec.ts
+++ b/src/__tests__/parsers/integer.spec.ts
@@ -1,72 +1,66 @@
-import { suite } from 'uvu'
-
 import { int, uint } from '../../parsers/integer'
-import { testFailure, testSuccess } from '../@helpers'
+import { describe, testFailure, testSuccess } from '../@helpers'
 
-let it = suite('int')
+describe('int', (it) => {
+  it('should succeed if given a signed integer', () => {
+    const tcases = [
+      ['0', 0],
+      ['2', 2],
+      ['20', 20],
+      ['-2', -2],
+      ['-20', -20]
+    ] as const
 
-it('should succeed if given a signed integer', () => {
-  const tcases = [
-    ['0', 0],
-    ['2', 2],
-    ['20', 20],
-    ['-2', -2],
-    ['-20', -20]
-  ] as const
+    tcases.forEach(([input, value]) => {
+      testSuccess(input, value, int())
+    })
+  })
 
-  tcases.forEach(([input, value]) => {
-    testSuccess(input, value, int())
+  it('should succeed with hexadecimal value if radix = 16', () => {
+    testSuccess('100', 256, int(16))
+  })
+
+  it('should succeed with octal value if radix = 8', () => {
+    testSuccess('100', 64, int(8))
+  })
+
+  it('should fail if given something else', () => {
+    ;['string', '-+', ' '].forEach((tcase) => {
+      testFailure(tcase, int())
+    })
   })
 })
 
-it('should succeed with hexadecimal value if radix = 16', () => {
-  testSuccess('100', 256, int(16))
-})
+describe('uint', (it) => {
+  it('should succeed if given an unsigned integer', () => {
+    const tcases = [
+      ['0', 0],
+      ['2', 2],
+      ['20', 20]
+    ] as const
 
-it('should succeed with octal value if radix = 8', () => {
-  testSuccess('100', 64, int(8))
-})
+    tcases.forEach(([input, value]) => {
+      testSuccess(input, value, uint())
+    })
+  })
 
-it('should fail if given something else', () => {
-  ;['string', '-+', ' '].forEach((tcase) => {
-    testFailure(tcase, int())
+  it('should succeed with hexadecimal value if radix = 16', () => {
+    testSuccess('100', 256, uint(16))
+  })
+
+  it('should succeed with octal value if radix = 8', () => {
+    testSuccess('100', 64, uint(8))
+  })
+
+  it('should fail if given a signed integer', () => {
+    ;['-20', '-2'].forEach((tcase) => {
+      testFailure(tcase, uint())
+    })
+  })
+
+  it('should fail if given something else', () => {
+    ;['string', '-+', ' '].forEach((tcase) => {
+      testFailure(tcase, uint())
+    })
   })
 })
-
-it.run()
-
-it = suite('uint')
-
-it('should succeed if given an unsigned integer', () => {
-  const tcases = [
-    ['0', 0],
-    ['2', 2],
-    ['20', 20]
-  ] as const
-
-  tcases.forEach(([input, value]) => {
-    testSuccess(input, value, uint())
-  })
-})
-
-it('should succeed with hexadecimal value if radix = 16', () => {
-  testSuccess('100', 256, uint(16))
-})
-
-it('should succeed with octal value if radix = 8', () => {
-  testSuccess('100', 64, uint(8))
-})
-
-it('should fail if given a signed integer', () => {
-  ;['-20', '-2'].forEach((tcase) => {
-    testFailure(tcase, uint())
-  })
-})
-
-it('should fail if given something else', () => {
-  ;['string', '-+', ' '].forEach((tcase) => {
-    testFailure(tcase, uint())
-  })
-})
-
-it.run()

--- a/src/__tests__/parsers/letter.spec.ts
+++ b/src/__tests__/parsers/letter.spec.ts
@@ -1,77 +1,71 @@
-import { suite } from 'uvu'
-
 import { letter, letters } from '../../parsers/letter'
-import { result, run, should } from '../@helpers'
+import { describe, result, run, should } from '../@helpers'
 
-let it = suite('letter')
+describe('letter', (it) => {
+  it('should succeed with an ASCII letter', () => {
+    const actual = run(letter(), 'A')
+    const expected = result(true, 'A')
 
-it('should succeed with an ASCII letter', () => {
-  const actual = run(letter(), 'A')
-  const expected = result(true, 'A')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should succeed with a Unicode letter', () => {
+    const actual = run(letter(), 'Â')
+    const expected = result(true, 'Â')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed with a single letter if given multiple letters', () => {
+    const actual = run(letter(), 'ab')
+    const expected = result(true, 'a')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail if given something other than a letter', () => {
+    ;['1', '+', '~', '`', ':', `'`].forEach((tcase) => {
+      const actual = run(letter(), tcase)
+      const expected = result(false, 'letter')
+
+      should.matchState(actual, expected)
+    })
+  })
 })
 
-it('should succeed with a Unicode letter', () => {
-  const actual = run(letter(), 'Â')
-  const expected = result(true, 'Â')
+describe('letters', (it) => {
+  it('should succeed with an ASCII letter if given input with a single ASCII letter', () => {
+    const actual = run(letters(), 'A')
+    const expected = result(true, 'A')
 
-  should.matchState(actual, expected)
-})
+    should.matchState(actual, expected)
+  })
 
-it('should succeed with a single letter if given multiple letters', () => {
-  const actual = run(letter(), 'ab')
-  const expected = result(true, 'a')
+  it('should succeed with a Unicode letter if given input with a single Unicode letter', () => {
+    const actual = run(letters(), 'Â')
+    const expected = result(true, 'Â')
 
-  should.matchState(actual, expected)
-})
+    should.matchState(actual, expected)
+  })
 
-it('should fail if given something other than a letter', () => {
-  ;['1', '+', '~', '`', ':', `'`].forEach((tcase) => {
-    const actual = run(letter(), tcase)
-    const expected = result(false, 'letter')
+  it('should succeed with letters if given input with letters', () => {
+    const actual = run(letters(), 'Âne')
+    const expected = result(true, 'Âne')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed with letters if given input with letters and other symbols', () => {
+    const actual = run(letters(), 'Âne+9000')
+    const expected = result(true, 'Âne')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail if given something other than letters', () => {
+    const actual = run(letters(), '9000+Âne')
+    const expected = result(false, 'letters')
 
     should.matchState(actual, expected)
   })
 })
-
-it.run()
-
-it = suite('letters')
-
-it('should succeed with an ASCII letter if given input with a single ASCII letter', () => {
-  const actual = run(letters(), 'A')
-  const expected = result(true, 'A')
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed with a Unicode letter if given input with a single Unicode letter', () => {
-  const actual = run(letters(), 'Â')
-  const expected = result(true, 'Â')
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed with letters if given input with letters', () => {
-  const actual = run(letters(), 'Âne')
-  const expected = result(true, 'Âne')
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed with letters if given input with letters and other symbols', () => {
-  const actual = run(letters(), 'Âne+9000')
-  const expected = result(true, 'Âne')
-
-  should.matchState(actual, expected)
-})
-
-it('should fail if given something other than letters', () => {
-  const actual = run(letters(), '9000+Âne')
-  const expected = result(false, 'letters')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/parsers/nothing.spec.ts
+++ b/src/__tests__/parsers/nothing.spec.ts
@@ -1,15 +1,11 @@
-import { suite } from 'uvu'
-
 import { nothing } from '../../parsers/nothing'
-import { result, run, should } from '../@helpers'
+import { describe, result, run, should } from '../@helpers'
 
-const it = suite('nothing')
+describe('nothing', (it) => {
+  it('should succeed with null value', () => {
+    const actual = run(nothing(), 'test')
+    const expected = result(true, null)
 
-it('should succeed with null value', () => {
-  const actual = run(nothing(), 'test')
-  const expected = result(true, null)
-
-  should.matchState(actual, expected)
+    should.matchState(actual, expected)
+  })
 })
-
-it.run()

--- a/src/__tests__/parsers/regexp.spec.ts
+++ b/src/__tests__/parsers/regexp.spec.ts
@@ -1,73 +1,69 @@
-import { suite } from 'uvu'
-
 import { regexp } from '../../parsers/regexp'
-import { result, run, should } from '../@helpers'
+import { describe, result, run, should } from '../@helpers'
 
-const it = suite('regexp')
+describe('regexp', (it) => {
+  it('should succeed if given matching input', () => {
+    const actualDigit = run(regexp(/\d/g, 'digit'), '0')
+    const expectedDigit = result(true, '0')
 
-it('should succeed if given matching input', () => {
-  const actualDigit = run(regexp(/\d/g, 'digit'), '0')
-  const expectedDigit = result(true, '0')
+    const actualDigits = run(regexp(/\d+/g, 'digits'), '9000')
+    const expectedDigits = result(true, '9000')
 
-  const actualDigits = run(regexp(/\d+/g, 'digits'), '9000')
-  const expectedDigits = result(true, '9000')
+    const actualMatchGroups = run(regexp(/\((\s)+\)/g, 'match-groups'), '( )')
+    const expectedMatchGroups = result(true, '( )')
 
-  const actualMatchGroups = run(regexp(/\((\s)+\)/g, 'match-groups'), '( )')
-  const expectedMatchGroups = result(true, '( )')
+    should.matchState(actualDigit, expectedDigit)
+    should.matchState(actualDigits, expectedDigits)
+    should.matchState(actualMatchGroups, expectedMatchGroups)
+  })
 
-  should.matchState(actualDigit, expectedDigit)
-  should.matchState(actualDigits, expectedDigits)
-  should.matchState(actualMatchGroups, expectedMatchGroups)
+  it('should succeed if given a RegExp with Unicode flag', () => {
+    const actualReEmoji = run(regexp(/\w+\s+👌/gu, 'words, spaces, ok emoji'), 'Yes 👌')
+    const expectedReEmoji = result(true, 'Yes 👌')
+
+    should.matchState(actualReEmoji, expectedReEmoji)
+  })
+
+  it('should succeed if given a RegExp with Unicode property escapes', () => {
+    const actualReEmoji = run(regexp(/\p{Emoji_Presentation}+/gu, 'emoji'), '👌👌👌')
+    const expectedReEmoji = result(true, '👌👌👌')
+
+    const actualReNonLatin = run(regexp(/\P{Script_Extensions=Latin}+/gu, 'non-latin'), '大阪')
+    const expectedReNonLation = result(true, '大阪')
+
+    should.matchState(actualReEmoji, expectedReEmoji)
+    should.matchState(actualReNonLatin, expectedReNonLation)
+  })
+
+  it('should succeeed if matches the beginning of input', () => {
+    const actualDigits = run(regexp(/\d{2,3}/g, 'first-digits'), '90000')
+    const expectedDigits = result(true, '900')
+
+    should.matchState(actualDigits, expectedDigits)
+  })
+
+  it('should fail if does not match input', () => {
+    const actualDigitFailure = run(regexp(/\d/g, 'digit'), 'hello')
+    const expectedDigitFailure = result(false, 'digit')
+
+    const actualEitherFailure = run(regexp(/(spec|test)/g, 'either'), 'spock')
+    const expectedEitherFailure = result(false, 'either')
+
+    should.matchState(actualDigitFailure, expectedDigitFailure)
+    should.matchState(actualEitherFailure, expectedEitherFailure)
+  })
+
+  it(`should fail if given zero input and regexp with 'one or more' quantifier`, () => {
+    const actualZeroFailure = run(regexp(/\d+/g, 'digits+'), '')
+    const expectedZeroFailure = result(false, 'digits+')
+
+    should.matchState(actualZeroFailure, expectedZeroFailure)
+  })
+
+  it(`should succeed if given zero input and regexp with 'zero or more' quantifier`, () => {
+    const actualZeroSuccess = run(regexp(/\d*/g, 'digits*'), '')
+    const expectedZeroSuccess = result(true, '')
+
+    should.matchState(actualZeroSuccess, expectedZeroSuccess)
+  })
 })
-
-it('should succeed if given a RegExp with Unicode flag', () => {
-  const actualReEmoji = run(regexp(/\w+\s+👌/gu, 'words, spaces, ok emoji'), 'Yes 👌')
-  const expectedReEmoji = result(true, 'Yes 👌')
-
-  should.matchState(actualReEmoji, expectedReEmoji)
-})
-
-it('should succeed if given a RegExp with Unicode property escapes', () => {
-  const actualReEmoji = run(regexp(/\p{Emoji_Presentation}+/gu, 'emoji'), '👌👌👌')
-  const expectedReEmoji = result(true, '👌👌👌')
-
-  const actualReNonLatin = run(regexp(/\P{Script_Extensions=Latin}+/gu, 'non-latin'), '大阪')
-  const expectedReNonLation = result(true, '大阪')
-
-  should.matchState(actualReEmoji, expectedReEmoji)
-  should.matchState(actualReNonLatin, expectedReNonLation)
-})
-
-it('should succeeed if matches the beginning of input', () => {
-  const actualDigits = run(regexp(/\d{2,3}/g, 'first-digits'), '90000')
-  const expectedDigits = result(true, '900')
-
-  should.matchState(actualDigits, expectedDigits)
-})
-
-it('should fail if does not match input', () => {
-  const actualDigitFailure = run(regexp(/\d/g, 'digit'), 'hello')
-  const expectedDigitFailure = result(false, 'digit')
-
-  const actualEitherFailure = run(regexp(/(spec|test)/g, 'either'), 'spock')
-  const expectedEitherFailure = result(false, 'either')
-
-  should.matchState(actualDigitFailure, expectedDigitFailure)
-  should.matchState(actualEitherFailure, expectedEitherFailure)
-})
-
-it(`should fail if given zero input and regexp with 'one or more' quantifier`, () => {
-  const actualZeroFailure = run(regexp(/\d+/g, 'digits+'), '')
-  const expectedZeroFailure = result(false, 'digits+')
-
-  should.matchState(actualZeroFailure, expectedZeroFailure)
-})
-
-it(`should succeed if given zero input and regexp with 'zero or more' quantifier`, () => {
-  const actualZeroSuccess = run(regexp(/\d*/g, 'digits*'), '')
-  const expectedZeroSuccess = result(true, '')
-
-  should.matchState(actualZeroSuccess, expectedZeroSuccess)
-})
-
-it.run()

--- a/src/__tests__/parsers/rest.spec.ts
+++ b/src/__tests__/parsers/rest.spec.ts
@@ -1,26 +1,22 @@
-import { suite } from 'uvu'
-
 import { sequence } from '../../combinators/sequence'
 import { rest } from '../../parsers/rest'
 import { string } from '../../parsers/string'
-import { result, run, should } from '../@helpers'
+import { describe, result, run, should } from '../@helpers'
 
-const it = suite('rest')
+describe('rest', (it) => {
+  it('should succeed with the rest of input', () => {
+    const parser = sequence(string('start'), rest())
+    const actual = run(parser, 'startend')
+    const expected = result(true, ['start', 'end'])
 
-it('should succeed with the rest of input', () => {
-  const parser = sequence(string('start'), rest())
-  const actual = run(parser, 'startend')
-  const expected = result(true, ['start', 'end'])
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should succeed with empty string if no input left to consume', () => {
+    const parser = sequence(string('start'), rest())
+    const actual = run(parser, 'start')
+    const expected = result(true, ['start', ''])
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should succeed with empty string if no input left to consume', () => {
-  const parser = sequence(string('start'), rest())
-  const actual = run(parser, 'start')
-  const expected = result(true, ['start', ''])
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/parsers/run.spec.ts
+++ b/src/__tests__/parsers/run.spec.ts
@@ -1,33 +1,29 @@
-import { suite } from 'uvu'
-
 import { defer } from '../../parsers/defer'
 import { run } from '../../parsers/run'
 import { string } from '../../parsers/string'
-import { result, should, testFailure } from '../@helpers'
+import { describe, result, should, testFailure } from '../@helpers'
 
-const it = suite('run')
+describe('run', (it) => {
+  it('should succeed if given a succeeding parser', () => {
+    const parser = string('runnable')
+    const actual = run(parser).with('runnable')
+    const expected = result(true, 'runnable')
 
-it('should succeed if given a succeeding parser', () => {
-  const parser = string('runnable')
-  const actual = run(parser).with('runnable')
-  const expected = result(true, 'runnable')
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should fail if given a failing parser', () => {
+    const deferred = defer<string>()
+
+    deferred.with(string('deferred'))
+
+    const actual = run(deferred).with('lazy')
+    const expected = result(false, 'deferred')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should throw if given a non-initialized deferred parser', () => {
+    testFailure('deffered', defer<string>())
+  })
 })
-
-it('should fail if given a failing parser', () => {
-  const deferred = defer<string>()
-
-  deferred.with(string('deferred'))
-
-  const actual = run(deferred).with('lazy')
-  const expected = result(false, 'deferred')
-
-  should.matchState(actual, expected)
-})
-
-it('should throw if given a non-initialized deferred parser', () => {
-  testFailure('deffered', defer<string>())
-})
-
-it.run()

--- a/src/__tests__/parsers/string.spec.ts
+++ b/src/__tests__/parsers/string.spec.ts
@@ -1,93 +1,87 @@
-import { suite } from 'uvu'
-
 import { string, ustring } from '../../parsers/string'
-import { run, result, should } from '../@helpers'
+import { run, result, should, describe } from '../@helpers'
 
-let it = suite('ustring')
+describe('ustring', (it) => {
+  it('should succeed if given an ASCII string', () => {
+    const tcase = 'test'
 
-it('should succeed if given an ASCII string', () => {
-  const tcase = 'test'
-
-  const actual = run(ustring(tcase), tcase)
-  const expected = result(true, tcase)
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed if given a Unicode string', () => {
-  ;['语言处理', 'Hëllø!', 'Family :: 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦'].forEach((tcase) => {
     const actual = run(ustring(tcase), tcase)
     const expected = result(true, tcase)
 
     should.matchState(actual, expected)
   })
+
+  it('should succeed if given a Unicode string', () => {
+    ;['语言处理', 'Hëllø!', 'Family :: 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦 👨‍👩‍👧‍👦'].forEach((tcase) => {
+      const actual = run(ustring(tcase), tcase)
+      const expected = result(true, tcase)
+
+      should.matchState(actual, expected)
+    })
+  })
+
+  it('should succeed if given a repetitive input', () => {
+    const tcase = 'test'
+
+    const actual = run(ustring(tcase), tcase.repeat(2))
+    const expected = result(true, tcase)
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail if given a non-matching input', () => {
+    const tcase = 'test'
+
+    const actual = run(ustring(tcase), 'wrong')
+    const expected = result(false, tcase)
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail if given a zero-length input', () => {
+    const tcase = 'test'
+
+    const actual = run(ustring(tcase), '')
+    const expected = result(false, tcase)
+
+    should.matchState(actual, expected)
+  })
 })
 
-it('should succeed if given a repetitive input', () => {
-  const tcase = 'test'
+describe('string', (it) => {
+  it('should succeed if given an ASCII string', () => {
+    const tcase = 'test'
 
-  const actual = run(ustring(tcase), tcase.repeat(2))
-  const expected = result(true, tcase)
+    const actual = run(string(tcase), tcase)
+    const expected = result(true, tcase)
 
-  should.matchState(actual, expected)
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed if given a repetitive input', () => {
+    const tcase = 'test'
+
+    const actual = run(string(tcase), tcase.repeat(2))
+    const expected = result(true, tcase)
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail if given a non-matching input', () => {
+    const tcase = 'test'
+
+    const actual = run(string(tcase), 'wrong')
+    const expected = result(false, tcase)
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail if given a zero-length input', () => {
+    const tcase = 'test'
+
+    const actual = run(string(tcase), '')
+    const expected = result(false, tcase)
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should fail if given a non-matching input', () => {
-  const tcase = 'test'
-
-  const actual = run(ustring(tcase), 'wrong')
-  const expected = result(false, tcase)
-
-  should.matchState(actual, expected)
-})
-
-it('should fail if given a zero-length input', () => {
-  const tcase = 'test'
-
-  const actual = run(ustring(tcase), '')
-  const expected = result(false, tcase)
-
-  should.matchState(actual, expected)
-})
-
-it.run()
-
-it = suite('string')
-
-it('should succeed if given an ASCII string', () => {
-  const tcase = 'test'
-
-  const actual = run(string(tcase), tcase)
-  const expected = result(true, tcase)
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed if given a repetitive input', () => {
-  const tcase = 'test'
-
-  const actual = run(string(tcase), tcase.repeat(2))
-  const expected = result(true, tcase)
-
-  should.matchState(actual, expected)
-})
-
-it('should fail if given a non-matching input', () => {
-  const tcase = 'test'
-
-  const actual = run(string(tcase), 'wrong')
-  const expected = result(false, tcase)
-
-  should.matchState(actual, expected)
-})
-
-it('should fail if given a zero-length input', () => {
-  const tcase = 'test'
-
-  const actual = run(string(tcase), '')
-  const expected = result(false, tcase)
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/parsers/whitespace.spec.ts
+++ b/src/__tests__/parsers/whitespace.spec.ts
@@ -1,47 +1,43 @@
-import { suite } from 'uvu'
-
 import { sequence } from '../../combinators/sequence'
 import { regexp } from '../../parsers/regexp'
 import { string } from '../../parsers/string'
 import { whitespace } from '../../parsers/whitespace'
-import { run, result, should } from '../@helpers'
+import { describe, run, result, should } from '../@helpers'
 
-const it = suite('whitespace')
+describe('whitespace', (it) => {
+  it('should succeed if given a string of spaces', () => {
+    const space = ' '
 
-it('should succeed if given a string of spaces', () => {
-  const space = ' '
+    const actual = run(whitespace(), space.repeat(4))
+    const expected = result(true, space.repeat(4))
 
-  const actual = run(whitespace(), space.repeat(4))
-  const expected = result(true, space.repeat(4))
+    should.matchState(actual, expected)
+  })
 
-  should.matchState(actual, expected)
+  it('should succeed if given a string starting with spaces', () => {
+    const space = ' '
+
+    const actual = run(whitespace(), space.repeat(4) + 'const')
+    const expected = result(true, space.repeat(4))
+
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed if given a mixed string with spaces', () => {
+    const identifier = regexp(/\w+/g, 'identifier')
+    const keyword = string('let')
+    const ws = whitespace()
+
+    const actual = run(sequence(keyword, ws, identifier), 'let identity')
+    const expected = result(true, ['let', ' ', 'identity'])
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail if given a non-matching input', () => {
+    const actual = run(sequence(string('let'), whitespace(), string('rec')), 'letrec')
+    const expected = result(false, 'whitespace')
+
+    should.matchState(actual, expected)
+  })
 })
-
-it('should succeed if given a string starting with spaces', () => {
-  const space = ' '
-
-  const actual = run(whitespace(), space.repeat(4) + 'const')
-  const expected = result(true, space.repeat(4))
-
-  should.matchState(actual, expected)
-})
-
-it('should succeed if given a mixed string with spaces', () => {
-  const identifier = regexp(/\w+/g, 'identifier')
-  const keyword = string('let')
-  const ws = whitespace()
-
-  const actual = run(sequence(keyword, ws, identifier), 'let identity')
-  const expected = result(true, ['let', ' ', 'identity'])
-
-  should.matchState(actual, expected)
-})
-
-it('should fail if given a non-matching input', () => {
-  const actual = run(sequence(string('let'), whitespace(), string('rec')), 'letrec')
-  const expected = result(false, 'whitespace')
-
-  should.matchState(actual, expected)
-})
-
-it.run()

--- a/src/__tests__/utils/unicode.spec.ts
+++ b/src/__tests__/utils/unicode.spec.ts
@@ -1,7 +1,5 @@
-import { suite } from 'uvu'
-import * as assert from 'uvu/assert'
-
 import { size } from '../../utils/unicode'
+import { describe, should } from '../@helpers'
 
 import { pangrams } from './unicode.data'
 
@@ -9,65 +7,63 @@ function check(locale: string) {
   const pangram = pangrams[locale]
 
   return Array.isArray(pangram)
-    ? pangram.forEach((data) => assert.equal(size(data.text), data.size))
-    : assert.equal(size(pangram.text), pangram.size)
+    ? pangram.forEach((data) => should.beEqual(size(data.text), data.size))
+    : should.beEqual(size(pangram.text), pangram.size)
 }
 
-const it = suite('unicode')
+describe('unicode', (it) => {
+  it('should correctly get length in bytes if given a unicode pangram', () => {
+    check('da')
+    check('en')
+    check('fr')
+    check('de')
+    check('iw')
+    check('hu')
+    check('is')
+    check('ga')
+    check('ja')
+    check('pl')
+    check('ru')
+    check('es')
+  })
 
-it('should correctly get length in bytes if given a unicode pangram', () => {
-  check('da')
-  check('en')
-  check('fr')
-  check('de')
-  check('iw')
-  check('hu')
-  check('is')
-  check('ga')
-  check('ja')
-  check('pl')
-  check('ru')
-  check('es')
-})
+  it('should correctly get length in bytes if given an emoji', () => {
+    should.beEqual(size(`⚡`), 3)
+    should.beEqual(size(`🦶🏿`), 8)
+    should.beEqual(size(`👨‍👨‍👧‍👧`), 25)
+    should.beEqual(size(`🏴󠁧󠁢󠁥󠁮󠁧󠁿`), 28)
+  })
 
-it('should correctly get length in bytes if given an emoji', () => {
-  assert.equal(size(`⚡`), 3)
-  assert.equal(size(`🦶🏿`), 8)
-  assert.equal(size(`👨‍👨‍👧‍👧`), 25)
-  assert.equal(size(`🏴󠁧󠁢󠁥󠁮󠁧󠁿`), 28)
-})
+  it('should correctly calculate length in bytes if given a char in range [E000, FFFF]', () => {
+    ;[
+      '\uE000', // Private Use Area
+      '\uF900', // CJK Compatibility Ideographs
+      '\uFB00', // Alphabetic Presentation Forms
+      '\uFB50', // Arabic Presentation Forms
+      '\uFE00', // Variation Selectors
+      '\uFE10', // Vertical Forms
+      '\uFE20', // Combining Half Marks
+      '\uFE30', // CJK Compatibility Forms
+      '\uFE50', // Small Form Variants
+      '\uFE70', // Arabic Presentation Forms-B
+      '\uFF00', // Half-Width and Fullwidth Forms
+      '\uFFF0' // Specials
+    ].forEach((char) => {
+      should.beEqual(size(char), 3)
+    })
+  })
 
-it('should correctly calculate length in bytes if given a char in range [E000, FFFF]', () => {
-  ;[
-    '\uE000', // Private Use Area
-    '\uF900', // CJK Compatibility Ideographs
-    '\uFB00', // Alphabetic Presentation Forms
-    '\uFB50', // Arabic Presentation Forms
-    '\uFE00', // Variation Selectors
-    '\uFE10', // Vertical Forms
-    '\uFE20', // Combining Half Marks
-    '\uFE30', // CJK Compatibility Forms
-    '\uFE50', // Small Form Variants
-    '\uFE70', // Arabic Presentation Forms-B
-    '\uFF00', // Half-Width and Fullwidth Forms
-    '\uFFF0' // Specials
-  ].forEach((char) => {
-    assert.equal(size(char), 3)
+  it('should throw if given an invalid single surrogate', () => {
+    ;[
+      '\uD800', // Missing low surrogate
+      '\uDB7F', // Missing low surrogate
+      '\uDB80', // Missing low surrogate
+      '\uDBFF', // Missing low surrogate
+      '\uDC00', // Invalid high surrogate
+      '\uDF80', // Invalid high surrogate
+      '\uDFFF' // Invalid high surrogate
+    ].forEach((char) => {
+      should.throw(() => size(char))
+    })
   })
 })
-
-it('should throw if given an invalid single surrogate', () => {
-  ;[
-    '\uD800', // Missing low surrogate
-    '\uDB7F', // Missing low surrogate
-    '\uDB80', // Missing low surrogate
-    '\uDBFF', // Missing low surrogate
-    '\uDC00', // Invalid high surrogate
-    '\uDF80', // Invalid high surrogate
-    '\uDFFF' // Invalid high surrogate
-  ].forEach((char) => {
-    assert.throws(() => size(char))
-  })
-})
-
-it.run()


### PR DESCRIPTION
As a last part of migration to `uvu` I solved reassignments of the it value with a describe helper.
It adds a familiar "jest-like" feelings to grouped tests and allows us to not call `it.run()` on each block (which could be forgotten). It also coincidentally removes a lot of noise from the test files.