### PR TITLE
feat(parsers/any): add `any` parser

### DIFF
--- a/docs/content/parsers/any.md
+++ b/docs/content/parsers/any.md
@@ -1,0 +1,48 @@
+---
+title: 'any'
+kind: 'primitive'
+description: 'any parses any single character from the input and returns it; it fails at the end of input.'
+---
+
+```typescript {{ withLineNumbers: false }}
+function any(): Parser<string>
+```
+
+## Description
+
+`any` parses any single character from the input and returns it. It fails at the end of input.
+
+## Usage
+
+```typescript
+const ManyParser = many(any())
+const SingleParser = any()
+```
+
+<details>
+  <summary>Output</summary>
+
+  ### Success
+
+  ```typescript
+  run(ManyParser).with('xyz')
+
+  {
+    isOk: true,
+    pos: 3,
+    value: [ 'x', 'y', 'z' ]
+  }
+  ```
+
+  ### Failure
+
+  ```typescript
+  run(SingleParser).with('')
+
+  {
+    isOk: false,
+    pos: 0,
+    expected: 'reached the end of input'
+  }
+  ```
+</details>

--- a/docs/src/lib/sidebar.ts
+++ b/docs/src/lib/sidebar.ts
@@ -60,6 +60,7 @@ export function getSidebarItems(): Array<SectionNode> {
       createItem('when', '/combinators/when')
     ]),
     createSection('Parsers', null, [
+      createItem('any', '/parsers/any'),
       createItem('defer', '/parsers/defer'),
       createItem('eof', '/parsers/eof'),
       createItem('eol', '/parsers/eol'),

--- a/src/__tests__/@helpers/index.ts
+++ b/src/__tests__/@helpers/index.ts
@@ -71,17 +71,22 @@ export const expectedCombinators = [
   'error',
   'sepBy',
   'many',
+  'many1',
   'map',
   'mapTo',
   'optional',
+  'sepBy',
+  'sepBy1',
   'sequence',
   'takeLeft',
   'takeMid',
   'takeRight',
-  'takeSides'
+  'takeSides',
+  'when'
 ] as const
 
 export const expectedParsers = [
+  'any',
   'defer',
   'eof',
   'eol',

--- a/src/__tests__/parsers/any.spec.ts
+++ b/src/__tests__/parsers/any.spec.ts
@@ -1,0 +1,23 @@
+import { many } from '../../combinators/many'
+import { any } from '../../parsers/any'
+import { run, result, should, describe, testFailure } from '../@helpers'
+
+describe('any', (it) => {
+  it('should succeed with a single character from the input stream', () => {
+    const actual = run(any(), 'xyz')
+    const expected = result(true, 'x')
+
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed only until it hits the end of input', () => {
+    const actual = run(many(any()), 'xyz')
+    const expected = result(true, ['x', 'y', 'z'])
+
+    should.matchState(actual, expected)
+  })
+
+  it('should fail at the end of input', () => {
+    testFailure('', any())
+  })
+})

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,3 +1,4 @@
+export * from './parsers/any'
 export * from './parsers/defer'
 export * from './parsers/eof'
 export * from './parsers/eol'

--- a/src/parsers/any.ts
+++ b/src/parsers/any.ts
@@ -1,0 +1,24 @@
+import { type Parser } from '../state'
+
+export function any(): Parser<string> {
+  return {
+    parse(input, pos) {
+      if (input.length === pos) {
+        return {
+          isOk: false,
+          pos,
+          expected: 'reached the end of input'
+        }
+      }
+
+      const nextPos = pos + 1
+      const value = input.substring(pos, nextPos)
+
+      return {
+        isOk: true,
+        pos: nextPos,
+        value
+      }
+    }
+  }
+}


### PR DESCRIPTION
This parser parses any single character from the input and returns it. It fails at the end of input.

It should work great with `takeUntil` and `skipUntil`.