### PR TITLE
refactor: change the output type to `number` for number parsers

### DIFF
--- a/docs/content/parsers/binary.md
+++ b/docs/content/parsers/binary.md
@@ -1,16 +1,16 @@
 ---
 title: 'binary'
 kind: 'composite'
-description: "binary parses a binary number prefixed with '0b' or '0B', e.g. '0b10', '0B10'. Returns parsed number as a string."
+description: "binary parses a binary number prefixed with '0b' or '0B', e.g. '0b10', '0B10'. Returns a decimal number obtained using parseInt with radix of 2."
 ---
 
 ```typescript {{ withLineNumbers: false }}
-function binary(): Parser<string>
+function binary(): Parser<number>
 ```
 
 ## Description
 
-`binary` parses a binary number prefixed with `0b` or `0B`, e.g. `0b10`, `0B10`. Returns parsed number **as a string**.
+`binary` parses a binary number prefixed with `0b` or `0B`, e.g. `0b10`, `0B10`. Returns **a decimal number** obtained using [parseInt] with radix of 2.
 
 ## Usage
 
@@ -29,7 +29,7 @@ const Parser = binary()
   {
     isOk: true,
     pos: 4,
-    value: '0b10'
+    value: 2
   }
   ```
 
@@ -45,3 +45,7 @@ const Parser = binary()
   }
   ```
 </details>
+
+<!-- Links. -->
+
+[parseInt]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

--- a/docs/content/parsers/float.md
+++ b/docs/content/parsers/float.md
@@ -1,18 +1,18 @@
 ---
 title: 'float'
 kind: 'composite'
-description: "float parses a float number with an optional minus sign, e.g. '0.25', '-7.90', '4.20'. Returns parsed number as a string."
+description: "float parses a float number with an optional minus sign, e.g. '0.25', '-7.90', '4.20'. Returns a decimal number obtained using parseInt with radix of 8."
 ---
 
 ```typescript {{ withLineNumbers: false }}
-function float(): Parser<string>
+function float(): Parser<number>
 ```
 
 ## Description
 
 > Note: It doesn't handle floats with exponent parts.
 
-`float` parses a float number with an optional minus sign, e.g. `0.25`, `-7.90`, `4.20`. Returns parsed number **as a string**.
+`float` parses a float number with an optional minus sign, e.g. `0.25`, `-7.90`, `4.20`. Returns **a decimal number** obtained using [parseFloat].
 
 ## Usage
 
@@ -31,7 +31,7 @@ const Parser = float()
   {
     isOk: true,
     pos: 5,
-    value: '-42.0'
+    value: -42
   }
   ```
 
@@ -47,3 +47,7 @@ const Parser = float()
   }
   ```
 </details>
+
+<!-- Links. -->
+
+[parseFloat]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat

--- a/docs/content/parsers/hex.md
+++ b/docs/content/parsers/hex.md
@@ -1,16 +1,16 @@
 ---
 title: 'hex'
 kind: 'composite'
-description: "hexadecimal parses a hexadecimal number prefixed with '0x' or '0X', e.g. '0xFF', '0XFF', '0xff'. Returns parsed number as a string."
+description: "hexadecimal parses a hexadecimal number prefixed with '0x' or '0X', e.g. '0xFF', '0XFF', '0xff'. Returns a decimal number obtained using parseInt with radix of 16."
 ---
 
 ```typescript {{ withLineNumbers: false }}
-function hex(): Parser<string>
+function hex(): Parser<number>
 ```
 
 ## Description
 
-`hex` parses a hexadecimal number prefixed with `0x` or `0X`, e.g. `0xFF`, `0XFF`, `0xff`. Returns parsed number **as a string**.
+`hex` parses a hexadecimal number prefixed with `0x` or `0X`, e.g. `0xFF`, `0XFF`, `0xff`. Returns **a decimal number** obtained using [parseInt] with radix of 16.
 
 ## Usage
 
@@ -29,7 +29,7 @@ const Parser = hex()
   {
     isOk: true,
     pos: 4,
-    value: '0xFF'
+    value: 255
   }
   ```
 
@@ -45,3 +45,7 @@ const Parser = hex()
   }
   ```
 </details>
+
+<!-- Links. -->
+
+[parseInt]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

--- a/docs/content/parsers/integer.md
+++ b/docs/content/parsers/integer.md
@@ -1,16 +1,16 @@
 ---
 title: 'integer'
 kind: 'composite'
-description: "integer parses an integer number with an optional minus sign, e.g. '0', '-7', '420'. Returns parsed number as a string."
+description: "integer parses an integer number with an optional minus sign, e.g. '0', '-7', '420'. Returns a decimal number obtained using parseInt with radix of 10."
 ---
 
 ```typescript {{ withLineNumbers: false }}
-function integer(): Parser<string>
+function integer(): Parser<number>
 ```
 
 ## Description
 
-`integer` parses an integer number with an optional minus sign, e.g. `0`, `-7`, `420`. Returns parsed number **as a string**.
+`integer` parses an integer number with an optional minus sign, e.g. `0`, `-7`, `420`. Returns **a decimal number** obtained using [parseInt] with radix of 10.
 
 ## Usage
 
@@ -29,7 +29,7 @@ const Parser = integer()
   {
     isOk: true,
     pos: 3,
-    value: '-42'
+    value: -42
   }
   ```
 
@@ -45,3 +45,7 @@ const Parser = integer()
   }
   ```
 </details>
+
+<!-- Links. -->
+
+[parseInt]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

--- a/docs/content/parsers/octal.md
+++ b/docs/content/parsers/octal.md
@@ -1,16 +1,16 @@
 ---
 title: 'octal'
 kind: 'composite'
-description: "octal parses an octal number prefixed with '0o' or '0O', e.g. '0o42', '0O42'. Returns parsed number as a string."
+description: "octal parses an octal number prefixed with '0o' or '0O', e.g. '0o42', '0O42'. Returns a decimal number obtained using parseInt with radix of 8."
 ---
 
 ```typescript {{ withLineNumbers: false }}
-function octal(): Parser<string>
+function octal(): Parser<number>
 ```
 
 ## Description
 
-`octal` parses an octal number prefixed with `0o` or `0O`, e.g. `0o42`, `0O42`. Returns parsed number **as a string**.
+`octal` parses an octal number prefixed with `0o` or `0O`, e.g. `0o42`, `0O42`. Returns **a decimal number** obtained using [parseInt] with radix of 8.
 
 ## Usage
 
@@ -29,7 +29,7 @@ const Parser = octal()
   {
     isOk: true,
     pos: 4,
-    value: '0o42'
+    value: 34
   }
   ```
 
@@ -45,3 +45,7 @@ const Parser = octal()
   }
   ```
 </details>
+
+<!-- Links. -->
+
+[parseInt]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

--- a/docs/content/parsers/whole.md
+++ b/docs/content/parsers/whole.md
@@ -1,16 +1,16 @@
 ---
 title: 'whole'
 kind: 'composite'
-description: "whole parses a positive whole number without leading zeros, e.g. '0', '7', '420'. Returns parsed number as a string."
+description: "whole parses a positive whole number without leading zeros, e.g. '0', '7', '420'. Returns a decimal number obtained using parseInt with radix of 10."
 ---
 
 ```typescript {{ withLineNumbers: false }}
-function whole(): Parser<string>
+function whole(): Parser<number>
 ```
 
 ## Description
 
-`whole` parses a positive whole number without leading zeros, e.g. `0`, `7`, `420`. Returns parsed number **as a string**.
+`whole` parses a positive whole number without leading zeros, e.g. `0`, `7`, `420`. Returns **a decimal number** obtained using [parseInt] with radix of 10.
 
 ## Usage
 
@@ -29,7 +29,7 @@ const Parser = whole()
   {
     isOk: true,
     pos: 2,
-    value: '42'
+    value: 42
   }
   ```
 
@@ -45,3 +45,7 @@ const Parser = whole()
   }
   ```
 </details>
+
+<!-- Links. -->
+
+[parseInt]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

--- a/src/__tests__/parsers/numbers.spec.ts
+++ b/src/__tests__/parsers/numbers.spec.ts
@@ -3,8 +3,14 @@ import { describe, testFailure, testSuccess } from '../@helpers'
 
 describe('hex', (it) => {
   it('should succeed if given a hexadecimal number', () => {
-    const tcases = ['0x1F', '0X1F', '0x1f', '0X1f']
-    tcases.forEach((tcase) => testSuccess(tcase, tcase, hex()))
+    const tcases = [
+      ['0x1F', 31],
+      ['0X1F', 31],
+      ['0x1f', 31],
+      ['0X1f', 31]
+    ] as const
+
+    tcases.forEach(([tcase, tresult]) => testSuccess(tcase, tresult, hex()))
   })
 
   it('should fail if given a non-hexadecimal number', () => {
@@ -15,8 +21,12 @@ describe('hex', (it) => {
 
 describe('binary', (it) => {
   it('should succeed if given a binary number', () => {
-    const tcases = ['0b10', '0B10']
-    tcases.forEach((tcase) => testSuccess(tcase, tcase, binary()))
+    const tcases = [
+      ['0b10', 2],
+      ['0B10', 2]
+    ] as const
+
+    tcases.forEach(([tcase, tresult]) => testSuccess(tcase, tresult, binary()))
   })
 
   it('should fail if given a non-binary number', () => {
@@ -27,8 +37,12 @@ describe('binary', (it) => {
 
 describe('octal', (it) => {
   it('should succeed if given an octal number', () => {
-    const tcases = ['0o42', '0O42']
-    tcases.forEach((tcase) => testSuccess(tcase, tcase, octal()))
+    const tcases = [
+      ['0o42', 34],
+      ['0O42', 34]
+    ] as const
+
+    tcases.forEach(([tcase, tresult]) => testSuccess(tcase, tresult, octal()))
   })
 
   it('should fail if given a non-octal number', () => {
@@ -40,7 +54,7 @@ describe('octal', (it) => {
 describe('whole', (it) => {
   it('should succeed if given a whole number', () => {
     const tcases = ['0', '1', '42', '1000']
-    tcases.forEach((tcase) => testSuccess(tcase, tcase, whole()))
+    tcases.forEach((tcase) => testSuccess(tcase, parseInt(tcase, 10), whole()))
   })
 
   it('should fail if given a non-whole number', () => {
@@ -52,7 +66,7 @@ describe('whole', (it) => {
 describe('integer', (it) => {
   it('should succeed if given an integer number', () => {
     const tcases = ['0', '1', '-1', '42', '-42']
-    tcases.forEach((tcase) => testSuccess(tcase, tcase, integer()))
+    tcases.forEach((tcase) => testSuccess(tcase, parseInt(tcase, 10), integer()))
   })
 
   it('should fail if given a non-integer number', () => {
@@ -64,7 +78,7 @@ describe('integer', (it) => {
 describe('float', (it) => {
   it('should succeed if given an float number', () => {
     const tcases = ['0.25', '4.20', '-42.0']
-    tcases.forEach((tcase) => testSuccess(tcase, tcase, float()))
+    tcases.forEach((tcase) => testSuccess(tcase, parseFloat(tcase), float()))
   })
 
   it('should fail if given a non-float number', () => {

--- a/src/parsers/numbers.ts
+++ b/src/parsers/numbers.ts
@@ -12,9 +12,9 @@ const FLOAT_RE = /-?[0-9]+\.[0-9]+/g
 /**
  * Parses a hexadecimal number prefixed with `0x` or `0X`, e.g. `0xFF`, `0XFF`, `0xff`.
  *
- * @returns Parsed hexadecimal number as a string
+ * @returns Parsed hexadecimal number as a decimal one
  */
-export function hex(): Parser<string> {
+export function hex(): Parser<number> {
   return {
     parse(input, pos) {
       const result = regexp(HEXADECIMAL_RE, 'hexadecimal number').parse(input, pos)
@@ -24,7 +24,7 @@ export function hex(): Parser<string> {
           return {
             isOk: true,
             pos: result.pos,
-            value: result.value
+            value: parseInt(result.value.slice(2), 16)
           }
         }
 
@@ -39,9 +39,9 @@ export function hex(): Parser<string> {
 /**
  * Parses a binary number prefixed with `0b` or `0B`, e.g. `0b101`, `0B101`.
  *
- * @returns Parsed binary number as a string
+ * @returns Parsed binary number as a decimal one
  */
-export function binary(): Parser<string> {
+export function binary(): Parser<number> {
   return {
     parse(input, pos) {
       const result = regexp(BINARY_RE, 'binary number').parse(input, pos)
@@ -51,7 +51,7 @@ export function binary(): Parser<string> {
           return {
             isOk: true,
             pos: result.pos,
-            value: result.value
+            value: parseInt(result.value.slice(2), 2)
           }
         }
 
@@ -66,9 +66,9 @@ export function binary(): Parser<string> {
 /**
  * Parses an octal number prefixed with `0o` or `0O`, e.g. `0o420`, `0O420`.
  *
- * @returns Parsed octal number as a string
+ * @returns Parsed octal number as a decimal one
  */
-export function octal(): Parser<string> {
+export function octal(): Parser<number> {
   return {
     parse(input, pos) {
       const result = regexp(OCTAL_RE, 'octal number').parse(input, pos)
@@ -78,7 +78,7 @@ export function octal(): Parser<string> {
           return {
             isOk: true,
             pos: result.pos,
-            value: result.value
+            value: parseInt(result.value.slice(2), 8)
           }
         }
 
@@ -93,9 +93,9 @@ export function octal(): Parser<string> {
 /**
  * Parses a positive whole number without leading zeros, e.g. `0`, `7`, `420`.
  *
- * @returns Parsed whole number as a string
+ * @returns Parsed whole number
  */
-export function whole(): Parser<string> {
+export function whole(): Parser<number> {
   return {
     parse(input, pos) {
       const result = regexp(WHOLE_RE, 'whole number').parse(input, pos)
@@ -105,7 +105,7 @@ export function whole(): Parser<string> {
           return {
             isOk: true,
             pos: result.pos,
-            value: result.value
+            value: parseInt(result.value, 10)
           }
         }
 
@@ -120,9 +120,9 @@ export function whole(): Parser<string> {
 /**
  * Parses an integer number with an optional minus sign, e.g. `0`, `-7`, `420`.
  *
- * @returns Parsed integer number as a string
+ * @returns Parsed integer number
  */
-export function integer(): Parser<string> {
+export function integer(): Parser<number> {
   return {
     parse(input, pos) {
       const result = regexp(INTEGER_RE, 'integer number').parse(input, pos)
@@ -132,7 +132,7 @@ export function integer(): Parser<string> {
           return {
             isOk: true,
             pos: result.pos,
-            value: result.value
+            value: parseInt(result.value, 10)
           }
         }
 
@@ -149,9 +149,9 @@ export function integer(): Parser<string> {
  *
  * Note: It doesn't handle floats with exponent parts.
  *
- * @returns Parsed float number as a string
+ * @returns Parsed float number
  */
-export function float(): Parser<string> {
+export function float(): Parser<number> {
   return {
     parse(input, pos) {
       const result = regexp(FLOAT_RE, 'float number').parse(input, pos)
@@ -161,7 +161,7 @@ export function float(): Parser<string> {
           return {
             isOk: true,
             pos: result.pos,
-            value: result.value
+            value: parseFloat(result.value)
           }
         }
 


### PR DESCRIPTION
- Now the following parsers return a `number` instead of a `string`: `integer`, `float`, `whole`, `hex`, `octal`, and `binary`.
- Changed tests accordingly.
- Changed docs accordingly.
- Changed tsdocs accordingly.

BREAKING CHANGE: The output type of number parsers has changed from `string` to `number`, i.e. these parsers now have the type of `Parser<number>` instead of `Parser<string>`.