### PR TITLE
fix(combinators/many): fix an edge case when combined with `noneOf`

### DIFF
--- a/src/__tests__/combinators/many.spec.ts
+++ b/src/__tests__/combinators/many.spec.ts
@@ -19,11 +19,20 @@ describe('many', () => {
     should.matchState(actual, expected)
   })
 })
+
 describe('many1', () => {
   it('should succeed with an array of matched strings', () => {
     const parser = many1(string('x!'))
     const actual = run(parser, 'x!x!x!')
     const expected = result(true, ['x!', 'x!', 'x!'])
+
+    should.matchState(actual, expected)
+  })
+
+  it('should succeed exactly one time', () => {
+    const parser = many1(string('x!'))
+    const actual = run(parser, 'x!y!y!')
+    const expected = result(true, ['x!'])
 
     should.matchState(actual, expected)
   })

--- a/src/combinators/many.ts
+++ b/src/combinators/many.ts
@@ -13,24 +13,21 @@ export function many<T>(parser: Parser<T>): SafeParser<Array<T>> {
       const values: Array<T> = []
       let nextPos = pos
 
-      while (true) {
+      while (nextPos < input.length) {
         const result = parser.parse(input, nextPos)
 
-        switch (result.isOk) {
-          case true: {
-            values.push(result.value)
-            nextPos = result.pos
-            break
-          }
-
-          case false: {
-            return {
-              isOk: true,
-              pos: nextPos,
-              value: values
-            }
-          }
+        if (result.isOk) {
+          values.push(result.value)
+          nextPos = result.pos
+        } else {
+          break
         }
+      }
+
+      return {
+        isOk: true,
+        pos: nextPos,
+        value: values
       }
     }
   }
@@ -54,7 +51,7 @@ export function many1<T>(parser: Parser<T>): Parser<Array<T>> {
 
         values.push(resultP.value)
 
-        while (true) {
+        while (nextPos < input.length) {
           const resultR = parser.parse(input, nextPos)
 
           if (resultR.isOk) {
@@ -63,11 +60,13 @@ export function many1<T>(parser: Parser<T>): Parser<Array<T>> {
             continue
           }
 
-          return {
-            isOk: true,
-            pos: nextPos,
-            value: values
-          }
+          break
+        }
+
+        return {
+          isOk: true,
+          pos: nextPos,
+          value: values
         }
       }
 


### PR DESCRIPTION
This PR fixes an edge case when `many` is combined with `noneOf`:

```ts
const INPUT = `one,two,three`

const Parser = sepBy(
  many(noneOf(',')),
  string(',')
)

console.log(run(Parser).with(INPUT))
```

Expected output:

```js
{
  isOk: true,
  pos: 13,
  value: [ [ 'o', 'n', 'e' ], [ 't', 'w', 'o' ], [ 't', 'h', 'r', 'e', 'e' ] ]
}
```

Before the fix node/browser would hang until they reach the maximum size for arrays.

> **Note**
>
> Seems more like an issue with `noneOf`, which may go out of the input bounds, but `many` and `many1` needed a fix as well.