### PR TITLE
fix(parsers/*): add checks for reaching end of input in `oneOf` and `noneOf`

### DIFF
--- a/src/__tests__/parsers/noneOf.spec.ts
+++ b/src/__tests__/parsers/noneOf.spec.ts
@@ -1,4 +1,5 @@
-import { noneOf } from '@parsers'
+import { sequence } from '@combinators'
+import { string, noneOf } from '@parsers'
 import { run, result, should, describe, testFailure, it } from '@testing'
 
 describe('noneOf', () => {
@@ -11,5 +12,9 @@ describe('noneOf', () => {
 
   it('should fail if input character is among given ones', () => {
     testFailure('y-combinator', noneOf('xyz'))
+  })
+
+  it('should fail if reached the end of input', () => {
+    testFailure('prefix', sequence(string('prefix'), noneOf('XY')))
   })
 })

--- a/src/__tests__/parsers/oneOf.spec.ts
+++ b/src/__tests__/parsers/oneOf.spec.ts
@@ -1,4 +1,5 @@
-import { oneOf } from '@parsers'
+import { sequence } from '@combinators'
+import { string, oneOf } from '@parsers'
 import { run, result, should, describe, testFailure, it } from '@testing'
 
 describe('oneOf', () => {
@@ -11,5 +12,9 @@ describe('oneOf', () => {
 
   it('should fail if input character is not among given ones', () => {
     testFailure('q-combinator', oneOf('xyz'))
+  })
+
+  it('should fail if reached the end of input', () => {
+    testFailure('prefix', sequence(string('prefix'), oneOf('XY')))
   })
 })

--- a/src/parsers/any.ts
+++ b/src/parsers/any.ts
@@ -12,7 +12,7 @@ export function any(): Parser<string> {
         return {
           isOk: false,
           pos,
-          expected: 'reached the end of input'
+          expected: 'any @ reached the end of input'
         }
       }
 

--- a/src/parsers/noneOf.ts
+++ b/src/parsers/noneOf.ts
@@ -12,6 +12,14 @@ export function noneOf(chars: string): Parser<string> {
 
   return {
     parse(input, pos) {
+      if (input.length === pos) {
+        return {
+          isOk: false,
+          pos,
+          expected: 'noneOf @ reached the end of input'
+        }
+      }
+
       const nextPos = pos + 1
       const char = input.substring(pos, nextPos)
 

--- a/src/parsers/oneOf.ts
+++ b/src/parsers/oneOf.ts
@@ -12,6 +12,14 @@ export function oneOf(chars: string): Parser<string> {
 
   return {
     parse(input, pos) {
+      if (input.length === pos) {
+        return {
+          isOk: false,
+          pos,
+          expected: 'oneOf @ reached the end of input'
+        }
+      }
+
       const nextPos = pos + 1
       const char = input.substring(pos, nextPos)
 


### PR DESCRIPTION
This PR adds checks for `oneOf` and `noneOf` to prevent these parsers from trying to reach out of input bounds.

`any` expectation message changed to match `oneOf` and `noneOf`.