### PR TITLE
feat(parsers/regexp): add injection of global flag if it's not present

### DIFF
--- a/docs/content/parsers/regexp.md
+++ b/docs/content/parsers/regexp.md
@@ -19,7 +19,7 @@ function regexp(rs: RegExp, expected: string): Parser<string>
 ## Implementation notes
 
 ::: warning
-It automatically injects `g` flag if it's *not* present so the parser will work correctly.
+If `g` flag is missing, it will be automatically injected. It's still better to always provide it to avoid small performance penalty and clearly document the intention.
 :::
 
 The regular expression must obey two simple rules:

--- a/docs/content/parsers/regexp.md
+++ b/docs/content/parsers/regexp.md
@@ -9,7 +9,7 @@ description: 'regexp parses a string that matches a provided regular expression.
 ## Signature
 
 ```ts
-function regexp(re: RegExp, expected: string): Parser<string>
+function regexp(rs: RegExp, expected: string): Parser<string>
 ```
 
 ## Description
@@ -18,9 +18,13 @@ function regexp(re: RegExp, expected: string): Parser<string>
 
 ## Implementation notes
 
+::: warning
+It automatically injects `g` flag if it's *not* present so the parser will work correctly.
+:::
+
 The regular expression must obey two simple rules:
 
-- It *does* use `g` flag. Flags like `u` and `i` are allowed and can be added if needed.
+- It *does* use g flag. Flags like u and i are allowed and can be added if needed.
 - It *doesn't* use `^` and `$` to match at the beginning or at the end of the text.
 
 ## Usage

--- a/src/__tests__/parsers/regexp.spec.ts
+++ b/src/__tests__/parsers/regexp.spec.ts
@@ -17,8 +17,44 @@ describe('regexp', () => {
     should.matchState(actualMatchGroups, expectedMatchGroups)
   })
 
+  it('should succeed if given matching input without Global flag', () => {
+    const actualDigit = run(regexp(/\d/, 'digit'), '0')
+    const expectedDigit = result(true, '0')
+
+    const actualDigits = run(regexp(/\d+/, 'digits'), '9000')
+    const expectedDigits = result(true, '9000')
+
+    const actualMatchGroups = run(regexp(/\((\s)+\)/, 'match-groups'), '( )')
+    const expectedMatchGroups = result(true, '( )')
+
+    should.matchState(actualDigit, expectedDigit)
+    should.matchState(actualDigits, expectedDigits)
+    should.matchState(actualMatchGroups, expectedMatchGroups)
+  })
+
+  it('should succeed if matches the beginning of input', () => {
+    const actualDigits = run(regexp(/\d{2,3}/g, 'first-digits'), '90000')
+    const expectedDigits = result(true, '900')
+
+    should.matchState(actualDigits, expectedDigits)
+  })
+
+  it('should succeed if matches the beginning of input without Global flag', () => {
+    const actualDigits = run(regexp(/\d{2,3}/, 'first-digits'), '90000')
+    const expectedDigits = result(true, '900')
+
+    should.matchState(actualDigits, expectedDigits)
+  })
+
   it('should succeed if given a RegExp with Unicode flag', () => {
     const actualReEmoji = run(regexp(/\w+\s+👌/gu, 'words, spaces, ok emoji'), 'Yes 👌')
+    const expectedReEmoji = result(true, 'Yes 👌')
+
+    should.matchState(actualReEmoji, expectedReEmoji)
+  })
+
+  it('should succeed if given a RegExp with Unicode flag and without Global one', () => {
+    const actualReEmoji = run(regexp(/\w+\s+👌/u, 'words, spaces, ok emoji'), 'Yes 👌')
     const expectedReEmoji = result(true, 'Yes 👌')
 
     should.matchState(actualReEmoji, expectedReEmoji)
@@ -29,17 +65,21 @@ describe('regexp', () => {
     const expectedReEmoji = result(true, '👌👌👌')
 
     const actualReNonLatin = run(regexp(/\P{Script_Extensions=Latin}+/gu, 'non-latin'), '大阪')
-    const expectedReNonLation = result(true, '大阪')
+    const expectedReNonLatin = result(true, '大阪')
 
     should.matchState(actualReEmoji, expectedReEmoji)
-    should.matchState(actualReNonLatin, expectedReNonLation)
+    should.matchState(actualReNonLatin, expectedReNonLatin)
   })
 
-  it('should succeeed if matches the beginning of input', () => {
-    const actualDigits = run(regexp(/\d{2,3}/g, 'first-digits'), '90000')
-    const expectedDigits = result(true, '900')
+  it('should succeed if given a RegExp with Unicode property escapes without Global flag', () => {
+    const actualReEmoji = run(regexp(/\p{Emoji_Presentation}+/u, 'emoji'), '👌👌👌')
+    const expectedReEmoji = result(true, '👌👌👌')
 
-    should.matchState(actualDigits, expectedDigits)
+    const actualReNonLatin = run(regexp(/\P{Script_Extensions=Latin}+/u, 'non-latin'), '大阪')
+    const expectedReNonLatin = result(true, '大阪')
+
+    should.matchState(actualReEmoji, expectedReEmoji)
+    should.matchState(actualReNonLatin, expectedReNonLatin)
   })
 
   it('should fail if does not match input', () => {

--- a/src/parsers/regexp.ts
+++ b/src/parsers/regexp.ts
@@ -6,15 +6,17 @@ import type { Parser } from '@types'
  *
  * The regular expression must obey two simple rules:
  *
- * - It *does* use `g` flag. Flags like `u` and `i` are allowed and can be added if needed.
+ * - It *does* use `g` flag. Flags like u and i are allowed and can be added if needed.
  * - It *doesn't* use `^` and `$` to match at the beginning or at the end of the text.
  *
- * @param re - Regular expression
+ * @param rs - Regular expression
  * @param expected - Error message if the regular expression does not match input
  *
  * @returns Matched string
  */
-export function regexp(re: RegExp, expected: string): Parser<string> {
+export function regexp(rs: RegExp, expected: string): Parser<string> {
+  const re = rs.global ? rs : new RegExp(rs.source, rs.flags + 'g')
+
   return {
     parse(input, pos) {
       // Reset RegExp index, because we abuse the 'g' flag.

--- a/src/parsers/regexp.ts
+++ b/src/parsers/regexp.ts
@@ -9,6 +9,9 @@ import type { Parser } from '@types'
  * - It *does* use `g` flag. Flags like u and i are allowed and can be added if needed.
  * - It *doesn't* use `^` and `$` to match at the beginning or at the end of the text.
  *
+ * If `g` flag is missing, it will be automatically injected. It's still better to always provide it
+ * to avoid small performance penalty and clearly document the intention.
+ *
  * @param rs - Regular expression
  * @param expected - Error message if the regular expression does not match input
  *


### PR DESCRIPTION
This PR closes https://github.com/norskeld/sigma/issues/55

Outstanding issues before merge:

- Should this be categorized as a fix and not feat? It's not breaking anything that worked correctly before, technically it's an implementation detail that should've been avoided, but because of the unclear docs and lack of context this could've been perceived as a bug.

- Are doc changes sufficient?