### PR TITLE
feat: add spans

### DIFF
--- a/docs/content/combinators/attempt.md
+++ b/docs/content/combinators/attempt.md
@@ -18,7 +18,7 @@ function attempt<T>(parser: Parser<T>): Parser<T>
 
 ## Usage
 
-The example is the same as in the docs for [`lookahead` combinators][lookahead]. Notice how differs the output for the last failing case: `attempt` doesn't consume any input, i.e. it doesn't advance `pos`.
+The example is the same as in the docs for [`lookahead` combinators][lookahead].
 
 ```ts
 const Parser = sequence(
@@ -40,6 +40,8 @@ run(Parser).with('hello lettuce')
 }
 ```
 :::
+
+Notice how differs the output for the last failing case: `attempt` doesn't consume any input, i.e. it doesn't advance `pos`.
 
 ::: danger Failure
 ```ts

--- a/docs/content/combinators/attempt.md
+++ b/docs/content/combinators/attempt.md
@@ -34,6 +34,7 @@ run(Parser).with('hello lettuce')
 
 {
   isOk: true,
+  span: [ 0, 13 ],
   pos: 13,
   value: [ 'hello', 'let', 'lettuce' ]
 }
@@ -46,18 +47,18 @@ run(Parser).with('hello let')
 
 {
   isOk: false,
+  span: [ 6, 9 ],
   pos: 9, // [!code warning]
   expected: 'lettuce'
 }
 ```
-:::
-
-::: danger Failure
+---
 ```ts
 run(Parser).with('hello something')
 
 {
   isOk: false,
+  span: [ 6, 9 ],
   pos: 6, // [!code warning]
   expected: 'let'
 }

--- a/docs/content/combinators/chainl.md
+++ b/docs/content/combinators/chainl.md
@@ -64,7 +64,7 @@ run(Parser).with('10+10-5+15')
 You will get the following result:
 
 ::: tip Success
-```ts{4}
+```ts{5}
 {
   isOk: true,
   span: [ 0, 10 ],

--- a/docs/content/combinators/chainl.md
+++ b/docs/content/combinators/chainl.md
@@ -67,6 +67,7 @@ You will get the following result:
 ```ts{4}
 {
   isOk: true,
+  span: [ 0, 10 ],
   pos: 10,
   value: 30
 }
@@ -187,6 +188,7 @@ We will get the following result:
 ```ts
 {
   isOk: true,
+  span: [ 0, 12 ],
   pos: 12,
   value: 80
 }

--- a/docs/content/combinators/choice.md
+++ b/docs/content/combinators/choice.md
@@ -32,19 +32,35 @@ run(Parser).with('true')
 
 {
   isOk: true,
+  span: [ 0, 4 ],
   pos: 4,
   value: 'true'
 }
 ```
 :::
 
+Notice how the `expected` field differs depending on the input, specifically its length.
+
 ::: danger Failure
+```ts
+run(Parser).with('yank')
+
+{
+  isOk: false,
+  span: [ 0, 4 ],
+  pos: 0,
+  expected: 'true'
+}
+```
+---
 ```ts
 run(Parser).with('maybe')
 
 {
   isOk: false,
+  span: [ 0, 5 ],
   pos: 0,
-  expected: 'true'
+  expected: 'false'
 }
+```
 :::

--- a/docs/content/combinators/choice.md
+++ b/docs/content/combinators/choice.md
@@ -42,7 +42,7 @@ run(Parser).with('true')
 Notice how the `expected` field differs depending on the input, specifically its length.
 
 ::: danger Failure
-```ts
+```ts{7}
 run(Parser).with('yank')
 
 {
@@ -53,7 +53,7 @@ run(Parser).with('yank')
 }
 ```
 ---
-```ts
+```ts{7}
 run(Parser).with('maybe')
 
 {

--- a/docs/content/combinators/error.md
+++ b/docs/content/combinators/error.md
@@ -34,6 +34,7 @@ run(Parser).with('true')
 
 {
   isOk: true,
+  span: [ 0, 4 ],
   pos: 4,
   value: 'true'
 }
@@ -46,7 +47,8 @@ run(Parser).with('maybe')
 
 {
   isOk: false,
-  pos: 0,
+  span: [ 0, 5 ],
+  pos: 5,
   expected: "expecting either 'true' or 'false'"
 }
 :::

--- a/docs/content/combinators/lookahead.md
+++ b/docs/content/combinators/lookahead.md
@@ -1,7 +1,7 @@
 ---
 title: 'lookahead'
 kind: 'primitive'
-description: "lookahead combinator applies parser without consuming any input. If parser fails and consumes some input, so does lookahead."
+description: 'lookahead combinator applies parser without consuming any input. If parser fails and consumes some input, so does lookahead.'
 ---
 
 # {{ $frontmatter.title }} <Primitive />
@@ -34,6 +34,7 @@ run(Parser).with('hello lettuce')
 
 {
   isOk: true,
+  span: [ 0, 13 ],
   pos: 13,
   value: [ 'hello', 'let', 'lettuce' ]
 }
@@ -46,18 +47,18 @@ run(Parser).with('hello let')
 
 {
   isOk: false,
+  span: [ 6, 9 ],
   pos: 9,
   expected: 'lettuce'
 }
 ```
-:::
-
-::: danger Failure
+---
 ```ts
 run(Parser).with('hello something')
 
 {
   isOk: false,
+  span: [ 6, 9 ],
   pos: 9,
   expected: 'let'
 }

--- a/docs/content/combinators/many.md
+++ b/docs/content/combinators/many.md
@@ -28,18 +28,20 @@ run(Parser).with('+++')
 
 {
   isOk: true,
+  span: [ 0, 3 ],
   pos: 3,
   value: [ '+', '+', '+' ]
 }
 ```
 :::
 
-::: danger Failure
+::: danger Success
 ```ts
 run(Parser).with('---')
 
 {
   isOk: true,
+  span: [ 0, 0 ],
   pos: 0,
   value: []
 }

--- a/docs/content/combinators/many1.md
+++ b/docs/content/combinators/many1.md
@@ -28,6 +28,7 @@ run(Parser).with('+++')
 
 {
   isOk: true,
+  span: [ 0, 3 ],
   pos: 3,
   value: [ '+', '+', '+' ]
 }
@@ -40,8 +41,9 @@ run(Parser).with('---')
 
 {
   isOk: false,
-  pos: 0,
-  expected: 'at least one successful application of the parser'
+  span: [ 0, 1 ],
+  pos: 1,
+  expected: '+'
 }
 ```
 :::

--- a/docs/content/combinators/map.md
+++ b/docs/content/combinators/map.md
@@ -35,6 +35,7 @@ run(Parser).with('2+2')
 
 {
   isOk: true,
+  span: [ 0, 3 ],
   pos: 3,
   value: 4
 }
@@ -47,7 +48,8 @@ run(Parser).with('2-2')
 
 {
   isOk: false,
-  pos: 1,
+  span: [ 1, 2 ],
+  pos: 2,
   expected: '+'
 }
 ```

--- a/docs/content/combinators/mapTo.md
+++ b/docs/content/combinators/mapTo.md
@@ -31,6 +31,7 @@ run(Parser).with('2+2')
 
 {
   isOk: true,
+  span: [ 0, 3 ],
   pos: 3,
   value: 5
 }
@@ -43,7 +44,8 @@ run(Parser).with('2-2')
 
 {
   isOk: false,
-  pos: 1,
+  span: [ 1, 2 ],
+  pos: 2,
   expected: '+'
 }
 ```

--- a/docs/content/combinators/optional.md
+++ b/docs/content/combinators/optional.md
@@ -31,8 +31,20 @@ run(Parser).with('-2')
 
 {
   isOk: true,
+  pan: [ 0, 2 ],
   pos: 2,
   value: [ '-', 2 ]
+}
+```
+---
+```ts
+run(Parser).with('2')
+
+{
+  isOk: true,
+  pan: [ 0, 1 ],
+  pos: 1,
+  value: [ null, 2 ]
 }
 ```
 :::
@@ -43,6 +55,7 @@ run(Parser).with('~2')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'whole number'
 }

--- a/docs/content/combinators/sepBy.md
+++ b/docs/content/combinators/sepBy.md
@@ -28,6 +28,7 @@ run(Parser).with('1+2+3+4')
 
 {
   isOk: true,
+  span: [ 0, 7 ],
   pos: 7,
   value: [ 1, 2, 3, 4 ]
 }
@@ -38,20 +39,20 @@ run(Parser).with('1-two')
 
 {
   isOk: true,
+  span: [ 0, 1 ],
   pos: 1,
   value: [ 1 ]
 }
 ```
-:::
-
-::: danger Failure
+---
 ```ts
-run(Parser).with('1-two')
+run(Parser).with('one+two')
 
 {
   isOk: true,
-  pos: 1,
-  value: [ 1 ]
+  span: [ 0, 0 ],
+  pos: 0,
+  value: []
 }
 ```
 :::

--- a/docs/content/combinators/sepBy1.md
+++ b/docs/content/combinators/sepBy1.md
@@ -28,6 +28,7 @@ run(Parser).with('1+2+3+4')
 
 {
   isOk: true,
+  span: [ 0, 7 ],
   pos: 7,
   value: [ 1, 2, 3, 4 ]
 }
@@ -38,6 +39,7 @@ run(Parser).with('1-two')
 
 {
   isOk: true,
+  span: [ 0, 1 ],
   pos: 1,
   value: [ 1 ]
 }
@@ -50,6 +52,7 @@ run(Parser).with('one+two')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'whole number'
 }

--- a/docs/content/combinators/sequence.md
+++ b/docs/content/combinators/sequence.md
@@ -33,6 +33,7 @@ run(Parser).with('hello world')
 
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: [ 'hello', ' ', 'world' ]
 }
@@ -45,6 +46,7 @@ run(Parser).with('hello friend')
 
 {
   isOk: false,
+  span: [ 6, 11 ],
   pos: 6,
   expected: 'world'
 }

--- a/docs/content/combinators/skipUntil.md
+++ b/docs/content/combinators/skipUntil.md
@@ -33,6 +33,7 @@ run(CommentParser).with('/* Hello */')
 
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: 'No comments!'
 }
@@ -45,6 +46,7 @@ run(FailingParser).with('one.')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'decimal digit'
 }

--- a/docs/content/combinators/takeLeft.md
+++ b/docs/content/combinators/takeLeft.md
@@ -31,6 +31,7 @@ run(Parser).with('42 spartans')
 
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: 42
 }
@@ -43,6 +44,7 @@ run(Parser).with('42 haskellers')
 
 {
   isOk: false,
+  span: [ 3, 11 ],
   pos: 3,
   expected: 'spartans'
 }

--- a/docs/content/combinators/takeMid.md
+++ b/docs/content/combinators/takeMid.md
@@ -36,6 +36,7 @@ run(Parser).with('fn multiply x y')
 
 {
   isOk: true,
+  span: [ 0, 15 ],
   pos: 15,
   value: 'multiply'
 }
@@ -48,6 +49,7 @@ run(Parser).with('fn 100 x y')
 
 {
   isOk: false,
+  span: [ 3, 3 ],
   pos: 3,
   expected: 'letters'
 }

--- a/docs/content/combinators/takeRight.md
+++ b/docs/content/combinators/takeRight.md
@@ -31,6 +31,7 @@ run(Parser).with('let binding')
 
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: 'binding'
 }
@@ -43,6 +44,7 @@ run(Parser).with('let 42')
 
 {
   isOk: false,
+  span: [ 4, 4 ],
   pos: 4,
   expected: 'letters'
 }

--- a/docs/content/combinators/takeSides.md
+++ b/docs/content/combinators/takeSides.md
@@ -40,6 +40,7 @@ run(Parser).with('100 & 200')
 
 {
   isOk: true,
+  span: [ 0, 9 ],
   pos: 9,
   value: [ 100, 200 ]
 }
@@ -52,7 +53,8 @@ run(Parser).with('100 ^ 200')
 
 {
   isOk: false,
-  pos: 4,
+  span: [ 4, 5 ],
+  pos: 5,
   expected: '&'
 }
 ```

--- a/docs/content/combinators/takeUntil.md
+++ b/docs/content/combinators/takeUntil.md
@@ -33,6 +33,7 @@ run(CommentParser).with('/* Hello */')
 
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: [
     '/*',
@@ -49,6 +50,7 @@ run(FailingParser).with('one.')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'decimal digit'
 }

--- a/docs/content/combinators/when.md
+++ b/docs/content/combinators/when.md
@@ -1,7 +1,7 @@
 ---
 title: 'when'
 kind: 'primitive'
-description: "when combinator allows to create chained, context-aware parsers, that may depend on the output of the context parser."
+description: 'when combinator allows to create chained, context-aware parsers, that may depend on the output of the context parser.'
 ---
 
 # {{ $frontmatter.title }} <Primitive />
@@ -38,43 +38,41 @@ run(Parser).with('integer 42')
 
 {
   isOk: true,
+  span: [ 8, 10 ],
   pos: 10,
   value: 42
 }
 ```
-:::
-
-::: tip Success
+---
 ```ts
 run(Parser).with('string Something')
 
 {
   isOk: true,
+  span: [ 7, 16 ],
   pos: 16,
   value: 'Something'
 }
 ```
-:::
-
-::: tip Success
+---
 ```ts
 run(Parser).with('bracketed (Something)')
 
 {
   isOk: true,
+  span: [ 10, 21 ],
   pos: 21,
   value: 'Something'
 }
 ```
-:::
-
-::: tip Success
+---
 ```ts
-run(Parser).with('unknown input')
+run(Parser).with('some input')
 
 {
   isOk: true,
-  pos: 13,
+  span: [ 5, 10 ],
+  pos: 10,
   value: 'input'
 }
 ```
@@ -86,6 +84,7 @@ run(Parser).with('0x42')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'letters'
 }

--- a/docs/content/guides/primitives-and-composites.md
+++ b/docs/content/guides/primitives-and-composites.md
@@ -1,6 +1,6 @@
 ---
-title: Primitives and composites
-description: What is the difference?
+title: 'Primitives and composites'
+description: 'What is the difference?'
 ---
 
 # {{ $frontmatter.title }}

--- a/docs/content/parsers/any.md
+++ b/docs/content/parsers/any.md
@@ -29,6 +29,7 @@ run(ManyParser).with('xyz')
 
 {
   isOk: true,
+  span: [ 0, 3 ],
   pos: 3,
   value: [ 'x', 'y', 'z' ]
 }
@@ -41,8 +42,9 @@ run(SingleParser).with('')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
-  expected: 'reached the end of input'
+  expected: 'any @ reached the end of input'
 }
 ```
 :::

--- a/docs/content/parsers/binary.md
+++ b/docs/content/parsers/binary.md
@@ -28,6 +28,7 @@ run(Parser).with('0b10')
 
 {
   isOk: true,
+  span: [ 0, 4 ],
   pos: 4,
   value: 2
 }
@@ -40,6 +41,7 @@ run(Parser).with('b10')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'binary number'
 }

--- a/docs/content/parsers/defer.md
+++ b/docs/content/parsers/defer.md
@@ -27,16 +27,18 @@ function defer<T>(): Deferred<T>
 - Parsers: [defer], [integer], [string]
 :::
 
-In the example below we are parsing simple nested tuples like `(1,2,(3,(4,5)))` into an AST, which then can be somehow manipulated.
+In the example below we are parsing simple nested tuples like `(1,2,(3,(4,5)))` into an AST, which then can be somehow manipulated. Every parsed node also has a span, that is location information.
 
 ```ts
 interface NumberNode {
   type: 'number'
+  span: Span
   value: number
 }
 
 interface ListNode {
   type: 'list'
+  span: Span
   value: Array<NumberNode | ListNode>
 }
 
@@ -46,7 +48,7 @@ const TupleNumber = defer<NumberNode>()
 TupleNumber.with(
   map(
     integer(),
-    (value) => ({ type: 'number', value })
+    (value, span) => ({ type: 'number', span, value })
   )
 )
 
@@ -57,7 +59,7 @@ TupleList.with(
       sepBy(choice(TupleList, TupleNumber), string(',')),
       string(')')
     ),
-    (value) => ({ type: 'list', value })
+    (value, span) => ({ type: 'list', span, value })
   )
 )
 ```
@@ -74,21 +76,25 @@ We will get the following result:
 ```ts
 {
   isOk: true,
+  span: [ 0, 15 ],
   pos: 15,
   value: {
     type: 'list',
+    span: [ 0, 15 ],
     value: [
-      { type: 'number', value: 1 },
-      { type: 'number', value: 2 },
+      { type: 'number', span: [ 1, 2 ], value: 1 },
+      { type: 'number', span: [ 3, 4 ], value: 2 },
       {
         type: 'list',
+        span: [ 5, 14 ],
         value: [
-          { type: 'number', value: 3 },
+          { type: 'number', span: [ 6, 7 ], value: 3 },
           {
             type: 'list',
+            span: [ 8, 13 ],
             value: [
-              { type: 'number', value: 4 },
-              { type: 'number', value: 5 }
+              { type: 'number', span: [ 9, 10 ], value: 4 },
+              { type: 'number', span: [ 11, 12 ], value: 5 }
             ]
           }
         ]

--- a/docs/content/parsers/eof.md
+++ b/docs/content/parsers/eof.md
@@ -33,6 +33,7 @@ run(Parser).with(`<start><body><end>`)
 
 {
   isOk: true,
+  span: [ 0, 18 ],
   pos: 18,
   value: [ '<start>', '<body>', '<end>', null ]
 }
@@ -45,6 +46,7 @@ run(Parser).with(`<start><body><end>\n`)
 
 {
   isOk: false,
+  span: [ 18, 18 ],
   pos: 18,
   expected: 'end of input'
 }

--- a/docs/content/parsers/eol.md
+++ b/docs/content/parsers/eol.md
@@ -32,6 +32,7 @@ run(Parser).with(`<start>\n<body>\n<end>\n`)
 
 {
   isOk: true,
+  span: [ 0, 21 ],
   pos: 21,
   value: [
     [ '<start>', '\n' ],
@@ -48,6 +49,7 @@ run(Parser).with(`<start>\n<body><end>\n`)
 
 {
   isOk: false,
+  span: [ 14, 16 ],
   pos: 14,
   expected: 'end of line'
 }

--- a/docs/content/parsers/float.md
+++ b/docs/content/parsers/float.md
@@ -30,6 +30,7 @@ run(Parser).with('-42.0')
 
 {
   isOk: true,
+  span: [ 0, 5 ],
   pos: 5,
   value: -42
 }
@@ -42,6 +43,7 @@ run(Parser).with('42')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'float number'
 }

--- a/docs/content/parsers/hex.md
+++ b/docs/content/parsers/hex.md
@@ -28,6 +28,7 @@ run(Parser).with('0xFF')
 
 {
   isOk: true,
+  span: [ 0, 4 ],
   pos: 4,
   value: 255
 }
@@ -40,6 +41,7 @@ run(Parser).with('xFF')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'hexadecimal number'
 }

--- a/docs/content/parsers/integer.md
+++ b/docs/content/parsers/integer.md
@@ -28,8 +28,20 @@ run(Parser).with('-42')
 
 {
   isOk: true,
+  span: [ 0, 3 ],
   pos: 3,
   value: -42
+}
+```
+---
+```ts
+run(Parser).with('134912398891')
+
+{
+  isOk: true,
+  span: [ 0, 12 ],
+  pos: 12,
+  value: 134912398891
 }
 ```
 :::
@@ -40,6 +52,7 @@ run(Parser).with('x')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'integer number'
 }

--- a/docs/content/parsers/letter.md
+++ b/docs/content/parsers/letter.md
@@ -28,6 +28,7 @@ run(Parser).with('X')
 
 {
   isOk: true,
+  span: [ 0, 1 ],
   pos: 1,
   value: 'X'
 }
@@ -38,6 +39,7 @@ run(Parser).with('こ')
 
 {
   isOk: true,
+  span: [ 0, 1 ],
   pos: 1,
   value: 'こ'
 }
@@ -46,10 +48,11 @@ run(Parser).with('こ')
 
 ::: danger Failure
 ```ts
-run(Parser).with('8')
+run(Parser).with('42')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'letter'
 }

--- a/docs/content/parsers/letters.md
+++ b/docs/content/parsers/letters.md
@@ -28,18 +28,20 @@ run(Parser).with('XY')
 
 {
   isOk: true,
-  pos: 1,
+  span: [ 0, 2 ],
+  pos: 2,
   value: 'XY'
 }
 ```
 ---
 ```ts
-run(Parser).with('meaningOfLife42')
+run(Parser).with('meaningOfLifeIs42')
 
 {
   isOk: true,
-  pos: 13,
-  value: 'meaningOfLife'
+  span: [ 0, 15 ],
+  pos: 15,
+  value: 'meaningOfLifeIs'
 }
 ```
 :::
@@ -50,6 +52,7 @@ run(Parser).with('42')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'letters'
 }

--- a/docs/content/parsers/noneOf.md
+++ b/docs/content/parsers/noneOf.md
@@ -28,6 +28,7 @@ run(Parser).with('q-combinator')
 
 {
   isOk: true,
+  span: [ 0, 1 ],
   pos: 1,
   value: 'q'
 }
@@ -36,10 +37,11 @@ run(Parser).with('q-combinator')
 
 ::: danger Failure
 ```ts
-run(Parser).with('q-combinator')
+run(Parser).with('y-combinator')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'none of: x, y, z'
 }

--- a/docs/content/parsers/octal.md
+++ b/docs/content/parsers/octal.md
@@ -28,6 +28,7 @@ run(Parser).with('0o42')
 
 {
   isOk: true,
+  span: [ 0, 4 ],
   pos: 4,
   value: 34
 }
@@ -40,6 +41,7 @@ run(Parser).with('o42')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'octal number'
 }

--- a/docs/content/parsers/oneOf.md
+++ b/docs/content/parsers/oneOf.md
@@ -28,6 +28,7 @@ run(Parser).with('y-combinator')
 
 {
   isOk: true,
+  span: [ 0, 1 ],
   pos: 1,
   value: 'y'
 }
@@ -40,6 +41,7 @@ run(Parser).with('q-combinator')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'one of: x, y, z'
 }

--- a/docs/content/parsers/regexp.md
+++ b/docs/content/parsers/regexp.md
@@ -39,6 +39,7 @@ run(Parser).with('👌')
 
 {
   isOk: true,
+  span: [ 0, 2 ],
   pos: 2,
   value: '👌'
 }
@@ -51,6 +52,7 @@ run(Parser).with('大')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'emoji'
 }

--- a/docs/content/parsers/rest.md
+++ b/docs/content/parsers/rest.md
@@ -28,6 +28,7 @@ run(Parser).with('hello world')
 
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: ['hello', ' world']
 }

--- a/docs/content/parsers/run.md
+++ b/docs/content/parsers/run.md
@@ -30,6 +30,7 @@ run(string('hello world')).with('hello world')
 ```ts
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: 'hello world'
 }
@@ -40,6 +41,7 @@ run(string('hello world')).with('hello world')
 ```ts
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'hello world'
 }

--- a/docs/content/parsers/string.md
+++ b/docs/content/parsers/string.md
@@ -30,6 +30,7 @@ run(Parser).with('hello')
 
 {
   isOk: true,
+  span: [ 0, 5 ],
   pos: 5,
   value: 'hello'
 }
@@ -42,6 +43,7 @@ run(Parser).with('bye')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: 'hello'
 }

--- a/docs/content/parsers/tryRun.md
+++ b/docs/content/parsers/tryRun.md
@@ -30,6 +30,7 @@ tryRun(string('hello world')).with('hello world')
 ```ts
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: 'hello world'
 }

--- a/docs/content/parsers/ustring.md
+++ b/docs/content/parsers/ustring.md
@@ -38,6 +38,7 @@ run(Parser).with('语言处理')
 
 {
   isOk: true,
+  span: [ 0, 12 ],
   pos: 12,
   value: '语言处理'
 }
@@ -50,6 +51,7 @@ run(Parser).with('语言')
 
 {
   isOk: false,
+  span: [ 0, 0 ],
   pos: 0,
   expected: '语言处理'
 }

--- a/docs/content/parsers/whitespace.md
+++ b/docs/content/parsers/whitespace.md
@@ -28,6 +28,7 @@ run(Parser).with('hello world')
 
 {
   isOk: true,
+  span: [ 0, 11 ],
   pos: 11,
   value: [ 'hello', ' ', 'world' ]
 }
@@ -40,6 +41,7 @@ run(Parser).with('helloworld')
 
 {
   isOk: false,
+  span: [ 5, 5 ],
   pos: 5,
   expected: 'whitespace'
 }

--- a/docs/content/parsers/whole.md
+++ b/docs/content/parsers/whole.md
@@ -23,27 +23,29 @@ const Parser = whole()
 ```
 
 ::: tip Success
-  ```ts
-  run(Parser).with('42')
+```ts
+run(Parser).with('42')
 
-  {
-    isOk: true,
-    pos: 2,
-    value: 42
-  }
-  ```
+{
+  isOk: true,
+  span: [ 0, 2 ],
+  pos: 2,
+  value: 42
+}
+```
 :::
 
 ::: danger Failure
-  ```ts
-  run(Parser).with('x')
+```ts
+run(Parser).with('x')
 
-  {
-    isOk: false,
-    pos: 0,
-    expected: 'whole number'
-  }
-  ```
+{
+  isOk: false,
+  span: [ 0, 0 ],
+  pos: 0,
+  expected: 'whole number'
+}
+```
 :::
 
 <!-- Links. -->

--- a/src/__tests__/combinators/attempt.spec.ts
+++ b/src/__tests__/combinators/attempt.spec.ts
@@ -14,6 +14,7 @@ describe('attempt', () => {
 
     should.beStrictEqual(actual, {
       isOk: true,
+      span: [0, 13],
       pos: 13,
       value: ['hello', 'let', 'lettuce']
     })
@@ -24,6 +25,7 @@ describe('attempt', () => {
 
     should.beStrictEqual(actual, {
       isOk: false,
+      span: [6, 9],
       pos: 9,
       expected: 'lettuce'
     })
@@ -34,6 +36,7 @@ describe('attempt', () => {
 
     should.beStrictEqual(actual, {
       isOk: false,
+      span: [6, 6],
       pos: 6,
       expected: 'let'
     })

--- a/src/__tests__/combinators/lookahead.spec.ts
+++ b/src/__tests__/combinators/lookahead.spec.ts
@@ -14,6 +14,7 @@ describe('lookahead', () => {
 
     should.beStrictEqual(actual, {
       isOk: true,
+      span: [0, 13],
       pos: 13,
       value: ['hello', 'let', 'lettuce']
     })
@@ -24,6 +25,7 @@ describe('lookahead', () => {
 
     should.beStrictEqual(actual, {
       isOk: false,
+      span: [6, 9],
       pos: 9,
       expected: 'lettuce'
     })
@@ -34,6 +36,7 @@ describe('lookahead', () => {
 
     should.beStrictEqual(actual, {
       isOk: false,
+      span: [6, 9],
       pos: 9,
       expected: 'let'
     })

--- a/src/__tests__/parsers/tryRun.spec.ts
+++ b/src/__tests__/parsers/tryRun.spec.ts
@@ -16,7 +16,7 @@ describe('tryRun', () => {
     deferred.with(string('deferred'))
 
     const actual = () => tryRun(deferred).with('lazy')
-    const expected = new ParserError({ pos: 8, expected: 'deferred' })
+    const expected = new ParserError({ pos: 8, span: [0, 4], expected: 'deferred' })
 
     should.throwError(actual, expected)
   })

--- a/src/combinators/attempt.ts
+++ b/src/combinators/attempt.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Applies `parser` without consuming any input. It doesn't care if `parser` succeeds or fails, it
@@ -18,6 +18,7 @@ export function attempt<T>(parser: Parser<T>): Parser<T> {
         case true: {
           return {
             isOk: true,
+            span: [pos, pos] as Span,
             pos,
             value: result.value
           }
@@ -27,6 +28,7 @@ export function attempt<T>(parser: Parser<T>): Parser<T> {
         case false: {
           return {
             isOk: false,
+            span: [pos, pos] as Span,
             pos,
             expected: result.expected
           }

--- a/src/combinators/attempt.ts
+++ b/src/combinators/attempt.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Applies `parser` without consuming any input. It doesn't care if `parser` succeeds or fails, it
@@ -18,7 +18,7 @@ export function attempt<T>(parser: Parser<T>): Parser<T> {
         case true: {
           return {
             isOk: true,
-            span: [pos, pos] as Span,
+            span: [pos, pos],
             pos,
             value: result.value
           }
@@ -28,7 +28,7 @@ export function attempt<T>(parser: Parser<T>): Parser<T> {
         case false: {
           return {
             isOk: false,
-            span: [pos, pos] as Span,
+            span: [pos, pos],
             pos,
             expected: result.expected
           }

--- a/src/combinators/error.ts
+++ b/src/combinators/error.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Replaces `parser`'s error message with `expected`.
@@ -21,7 +21,7 @@ export function error<T>(parser: Parser<T>, expected: string): Parser<T> {
         case false: {
           return {
             isOk: false,
-            span: [pos, result.pos] as Span,
+            span: [pos, result.pos],
             pos,
             expected
           }

--- a/src/combinators/error.ts
+++ b/src/combinators/error.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Replaces `parser`'s error message with `expected`.
@@ -21,6 +21,7 @@ export function error<T>(parser: Parser<T>, expected: string): Parser<T> {
         case false: {
           return {
             isOk: false,
+            span: [pos, result.pos] as Span,
             pos,
             expected
           }

--- a/src/combinators/error.ts
+++ b/src/combinators/error.ts
@@ -22,7 +22,7 @@ export function error<T>(parser: Parser<T>, expected: string): Parser<T> {
           return {
             isOk: false,
             span: [pos, result.pos],
-            pos,
+            pos: result.pos,
             expected
           }
         }

--- a/src/combinators/lookahead.ts
+++ b/src/combinators/lookahead.ts
@@ -18,6 +18,7 @@ export function lookahead<T>(parser: Parser<T>): Parser<T> {
         case true: {
           return {
             isOk: true,
+            span: result.span,
             pos,
             value: result.value
           }

--- a/src/combinators/many.ts
+++ b/src/combinators/many.ts
@@ -1,4 +1,4 @@
-import type { Parser, SafeParser } from '@types'
+import type { Parser, SucceedingParser, Span } from '@types'
 
 /**
  * Applies `parser` *zero* or more times, collecting its results. Never fails.
@@ -7,7 +7,7 @@ import type { Parser, SafeParser } from '@types'
  *
  * @returns Array of the returned values of `parser`
  */
-export function many<T>(parser: Parser<T>): SafeParser<Array<T>> {
+export function many<T>(parser: Parser<T>): SucceedingParser<Array<T>> {
   return {
     parse(input, pos) {
       const values: Array<T> = []
@@ -26,6 +26,7 @@ export function many<T>(parser: Parser<T>): SafeParser<Array<T>> {
 
       return {
         isOk: true,
+        span: [pos, nextPos] as Span,
         pos: nextPos,
         value: values
       }
@@ -65,6 +66,7 @@ export function many1<T>(parser: Parser<T>): Parser<Array<T>> {
 
         return {
           isOk: true,
+          span: [pos, nextPos] as Span,
           pos: nextPos,
           value: values
         }

--- a/src/combinators/many.ts
+++ b/src/combinators/many.ts
@@ -1,4 +1,4 @@
-import type { Parser, SucceedingParser, Span } from '@types'
+import type { Parser, SucceedingParser } from '@types'
 
 /**
  * Applies `parser` *zero* or more times, collecting its results. Never fails.
@@ -26,7 +26,7 @@ export function many<T>(parser: Parser<T>): SucceedingParser<Array<T>> {
 
       return {
         isOk: true,
-        span: [pos, nextPos] as Span,
+        span: [pos, nextPos],
         pos: nextPos,
         value: values
       }
@@ -66,7 +66,7 @@ export function many1<T>(parser: Parser<T>): Parser<Array<T>> {
 
         return {
           isOk: true,
-          span: [pos, nextPos] as Span,
+          span: [pos, nextPos],
           pos: nextPos,
           value: values
         }

--- a/src/combinators/map.ts
+++ b/src/combinators/map.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Applies `fn` to the `parser`'s result.
@@ -8,17 +8,20 @@ import type { Parser } from '@types'
  *
  * @returns Result of `fn`
  */
-export function map<T, R>(parser: Parser<T>, fn: (value: T) => R): Parser<R> {
+export function map<T, R>(parser: Parser<T>, fn: (value: T, span: Span) => R): Parser<R> {
   return {
     parse(input, pos) {
       const result = parser.parse(input, pos)
 
       switch (result.isOk) {
         case true: {
+          const span = [pos, result.pos] as Span
+
           return {
             isOk: true,
+            span,
             pos: result.pos,
-            value: fn(result.value)
+            value: fn(result.value, span)
           }
         }
 

--- a/src/combinators/map.ts
+++ b/src/combinators/map.ts
@@ -15,7 +15,7 @@ export function map<T, R>(parser: Parser<T>, fn: (value: T, span: Span) => R): P
 
       switch (result.isOk) {
         case true: {
-          const span = [pos, result.pos] as Span
+          const span: Span = [pos, result.pos]
 
           return {
             isOk: true,

--- a/src/combinators/sepBy.ts
+++ b/src/combinators/sepBy.ts
@@ -1,7 +1,7 @@
 import { many } from './many'
 import { sequence } from './sequence'
 
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Parses *zero* or more occurrences of `parser`, separated by `sep`. Never fails.
@@ -23,10 +23,13 @@ export function sepBy<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>>
         const values = [resultP.value]
 
         // If the parsers succeed, concatenate the values sans the separator.
-        resultS.value.forEach(([, value]) => values.push(value))
+        for (const [, value] of resultS.value) {
+          values.push(value)
+        }
 
         return {
           isOk: true,
+          span: [pos, resultS.pos] as Span,
           pos: resultS.pos,
           value: values
         }
@@ -34,6 +37,7 @@ export function sepBy<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>>
 
       return {
         isOk: true,
+        span: [pos, resultP.pos] as Span,
         pos: resultP.pos,
         value: []
       }
@@ -61,10 +65,13 @@ export function sepBy1<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>
         const values = [resultP.value]
 
         // If the parsers succeed, concatenate the values sans the separator.
-        resultS.value.forEach(([, value]) => values.push(value))
+        for (const [, value] of resultS.value) {
+          values.push(value)
+        }
 
         return {
           isOk: true,
+          span: [pos, resultS.pos] as Span,
           pos: resultS.pos,
           value: values
         }
@@ -72,6 +79,7 @@ export function sepBy1<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>
 
       return {
         isOk: false,
+        span: [pos, resultP.pos] as Span,
         pos: resultP.pos,
         expected: resultP.expected
       }

--- a/src/combinators/sepBy.ts
+++ b/src/combinators/sepBy.ts
@@ -1,7 +1,7 @@
 import { many } from './many'
 import { sequence } from './sequence'
 
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Parses *zero* or more occurrences of `parser`, separated by `sep`. Never fails.
@@ -29,7 +29,7 @@ export function sepBy<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>>
 
         return {
           isOk: true,
-          span: [pos, resultS.pos] as Span,
+          span: [pos, resultS.pos],
           pos: resultS.pos,
           value: values
         }
@@ -37,7 +37,7 @@ export function sepBy<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>>
 
       return {
         isOk: true,
-        span: [pos, resultP.pos] as Span,
+        span: [pos, resultP.pos],
         pos: resultP.pos,
         value: []
       }
@@ -71,7 +71,7 @@ export function sepBy1<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>
 
         return {
           isOk: true,
-          span: [pos, resultS.pos] as Span,
+          span: [pos, resultS.pos],
           pos: resultS.pos,
           value: values
         }
@@ -79,7 +79,7 @@ export function sepBy1<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>
 
       return {
         isOk: false,
-        span: [pos, resultP.pos] as Span,
+        span: [pos, resultP.pos],
         pos: resultP.pos,
         expected: resultP.expected
       }

--- a/src/combinators/sequence.ts
+++ b/src/combinators/sequence.ts
@@ -1,4 +1,4 @@
-import type { Parser, ToTuple } from '@types'
+import type { Parser, Span, ToTuple } from '@types'
 
 /**
  * Applies `ps` parsers in order, until *all* of them succeed.
@@ -32,6 +32,7 @@ export function sequence<T>(...ps: Array<Parser<T>>): Parser<Array<T>> {
 
       return {
         isOk: true,
+        span: [pos, nextPos] as Span,
         pos: nextPos,
         value: values
       }

--- a/src/combinators/sequence.ts
+++ b/src/combinators/sequence.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span, ToTuple } from '@types'
+import type { Parser, ToTuple } from '@types'
 
 /**
  * Applies `ps` parsers in order, until *all* of them succeed.
@@ -32,7 +32,7 @@ export function sequence<T>(...ps: Array<Parser<T>>): Parser<Array<T>> {
 
       return {
         isOk: true,
-        span: [pos, nextPos] as Span,
+        span: [pos, nextPos],
         pos: nextPos,
         value: values
       }

--- a/src/combinators/until.ts
+++ b/src/combinators/until.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Applies source `parser`, collects its output, and stops after `terminator` parser succeeds.
@@ -23,6 +23,7 @@ export function takeUntil<T, S>(parser: Parser<T>, terminator: Parser<S>): Parse
           case true: {
             return {
               isOk: true,
+              span: [pos, resultT.pos] as Span,
               pos: resultT.pos,
               value: [values, resultT.value]
             }
@@ -68,6 +69,7 @@ export function skipUntil<T, S>(parser: Parser<T>, terminator: Parser<S>): Parse
           case true: {
             return {
               isOk: true,
+              span: [pos, resultT.pos] as Span,
               pos: resultT.pos,
               value: resultT.value
             }

--- a/src/combinators/until.ts
+++ b/src/combinators/until.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Applies source `parser`, collects its output, and stops after `terminator` parser succeeds.
@@ -23,7 +23,7 @@ export function takeUntil<T, S>(parser: Parser<T>, terminator: Parser<S>): Parse
           case true: {
             return {
               isOk: true,
-              span: [pos, resultT.pos] as Span,
+              span: [pos, resultT.pos],
               pos: resultT.pos,
               value: [values, resultT.value]
             }
@@ -69,7 +69,7 @@ export function skipUntil<T, S>(parser: Parser<T>, terminator: Parser<S>): Parse
           case true: {
             return {
               isOk: true,
-              span: [pos, resultT.pos] as Span,
+              span: [pos, resultT.pos],
               pos: resultT.pos,
               value: resultT.value
             }

--- a/src/parsers/any.ts
+++ b/src/parsers/any.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Parses any single character from the input and returns it. Fails at the end of input.
@@ -11,6 +11,7 @@ export function any(): Parser<string> {
       if (input.length === pos) {
         return {
           isOk: false,
+          span: [pos, pos] as Span,
           pos,
           expected: 'any @ reached the end of input'
         }
@@ -21,6 +22,7 @@ export function any(): Parser<string> {
 
       return {
         isOk: true,
+        span: [pos, nextPos] as Span,
         pos: nextPos,
         value
       }

--- a/src/parsers/any.ts
+++ b/src/parsers/any.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Parses any single character from the input and returns it. Fails at the end of input.
@@ -11,7 +11,7 @@ export function any(): Parser<string> {
       if (input.length === pos) {
         return {
           isOk: false,
-          span: [pos, pos] as Span,
+          span: [pos, pos],
           pos,
           expected: 'any @ reached the end of input'
         }
@@ -22,7 +22,7 @@ export function any(): Parser<string> {
 
       return {
         isOk: true,
-        span: [pos, nextPos] as Span,
+        span: [pos, nextPos],
         pos: nextPos,
         value
       }

--- a/src/parsers/defer.ts
+++ b/src/parsers/defer.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Intersection type to add a method for deferred parser definition.
@@ -71,7 +71,7 @@ export function defer<T>(): Deferred<T> {
 
       return {
         isOk: false,
-        span: [pos, pos] as Span,
+        span: [pos, pos],
         pos,
         expected: `Deferred parser wasn't initialized.`
       }

--- a/src/parsers/defer.ts
+++ b/src/parsers/defer.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Intersection type to add a method for deferred parser definition.
@@ -71,6 +71,7 @@ export function defer<T>(): Deferred<T> {
 
       return {
         isOk: false,
+        span: [pos, pos] as Span,
         pos,
         expected: `Deferred parser wasn't initialized.`
       }

--- a/src/parsers/eof.ts
+++ b/src/parsers/eof.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Only succeeds at the end of the input.
@@ -8,12 +8,11 @@ import type { Parser } from '@types'
 export function eof(): Parser<null> {
   return {
     parse(input, pos) {
-      const isEof = pos === input.length
-
-      switch (isEof) {
+      switch (pos === input.length) {
         case true: {
           return {
             isOk: true,
+            span: [pos, pos] as Span,
             pos: input.length,
             value: null
           }
@@ -22,6 +21,7 @@ export function eof(): Parser<null> {
         case false: {
           return {
             isOk: false,
+            span: [pos, pos] as Span,
             pos,
             expected: 'end of input'
           }

--- a/src/parsers/eof.ts
+++ b/src/parsers/eof.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Only succeeds at the end of the input.
@@ -12,7 +12,7 @@ export function eof(): Parser<null> {
         case true: {
           return {
             isOk: true,
-            span: [pos, pos] as Span,
+            span: [pos, pos],
             pos: input.length,
             value: null
           }
@@ -21,7 +21,7 @@ export function eof(): Parser<null> {
         case false: {
           return {
             isOk: false,
-            span: [pos, pos] as Span,
+            span: [pos, pos],
             pos,
             expected: 'end of input'
           }

--- a/src/parsers/noneOf.ts
+++ b/src/parsers/noneOf.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Ensures that none of the characters in the given string matches the current character.
@@ -15,6 +15,7 @@ export function noneOf(chars: string): Parser<string> {
       if (input.length === pos) {
         return {
           isOk: false,
+          span: [pos, pos] as Span,
           pos,
           expected: 'noneOf @ reached the end of input'
         }
@@ -26,6 +27,7 @@ export function noneOf(chars: string): Parser<string> {
       if (!charset.includes(char)) {
         return {
           isOk: true,
+          span: [pos, nextPos] as Span,
           pos: nextPos,
           value: char
         }
@@ -33,7 +35,8 @@ export function noneOf(chars: string): Parser<string> {
 
       return {
         isOk: false,
-        pos,
+        span: [pos, pos] as Span,
+        pos: nextPos,
         expected: `none of: ${charset.join(', ')}`
       }
     }

--- a/src/parsers/noneOf.ts
+++ b/src/parsers/noneOf.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Ensures that none of the characters in the given string matches the current character.
@@ -15,7 +15,7 @@ export function noneOf(chars: string): Parser<string> {
       if (input.length === pos) {
         return {
           isOk: false,
-          span: [pos, pos] as Span,
+          span: [pos, pos],
           pos,
           expected: 'noneOf @ reached the end of input'
         }
@@ -27,7 +27,7 @@ export function noneOf(chars: string): Parser<string> {
       if (!charset.includes(char)) {
         return {
           isOk: true,
-          span: [pos, nextPos] as Span,
+          span: [pos, nextPos],
           pos: nextPos,
           value: char
         }
@@ -35,7 +35,7 @@ export function noneOf(chars: string): Parser<string> {
 
       return {
         isOk: false,
-        span: [pos, pos] as Span,
+        span: [pos, pos],
         pos: nextPos,
         expected: `none of: ${charset.join(', ')}`
       }

--- a/src/parsers/nothing.ts
+++ b/src/parsers/nothing.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Simply resolves to `null`.
@@ -10,6 +10,7 @@ export function nothing(): Parser<null> {
     parse(_, pos) {
       return {
         isOk: true,
+        span: [pos, pos] as Span,
         pos,
         value: null
       }

--- a/src/parsers/nothing.ts
+++ b/src/parsers/nothing.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Simply resolves to `null`.
@@ -10,7 +10,7 @@ export function nothing(): Parser<null> {
     parse(_, pos) {
       return {
         isOk: true,
-        span: [pos, pos] as Span,
+        span: [pos, pos],
         pos,
         value: null
       }

--- a/src/parsers/numbers.ts
+++ b/src/parsers/numbers.ts
@@ -1,6 +1,6 @@
 import { regexp } from './regexp'
 
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 const HEXADECIMAL_RE = /0[xX][0-9a-fA-F]+/g
 const BINARY_RE = /0[bB][01]+/g
@@ -23,6 +23,7 @@ export function hex(): Parser<number> {
         case true: {
           return {
             isOk: true,
+            span: [pos, result.pos] as Span,
             pos: result.pos,
             value: parseInt(result.value.slice(2), 16)
           }
@@ -50,6 +51,7 @@ export function binary(): Parser<number> {
         case true: {
           return {
             isOk: true,
+            span: [pos, result.pos] as Span,
             pos: result.pos,
             value: parseInt(result.value.slice(2), 2)
           }
@@ -77,6 +79,7 @@ export function octal(): Parser<number> {
         case true: {
           return {
             isOk: true,
+            span: [pos, result.pos] as Span,
             pos: result.pos,
             value: parseInt(result.value.slice(2), 8)
           }
@@ -104,6 +107,7 @@ export function whole(): Parser<number> {
         case true: {
           return {
             isOk: true,
+            span: [pos, result.pos] as Span,
             pos: result.pos,
             value: parseInt(result.value, 10)
           }
@@ -131,6 +135,7 @@ export function integer(): Parser<number> {
         case true: {
           return {
             isOk: true,
+            span: [pos, result.pos] as Span,
             pos: result.pos,
             value: parseInt(result.value, 10)
           }
@@ -160,6 +165,7 @@ export function float(): Parser<number> {
         case true: {
           return {
             isOk: true,
+            span: [pos, result.pos] as Span,
             pos: result.pos,
             value: parseFloat(result.value)
           }

--- a/src/parsers/oneOf.ts
+++ b/src/parsers/oneOf.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Ensures that one of the characters in the given string matches the current character.
@@ -15,6 +15,7 @@ export function oneOf(chars: string): Parser<string> {
       if (input.length === pos) {
         return {
           isOk: false,
+          span: [pos, pos] as Span,
           pos,
           expected: 'oneOf @ reached the end of input'
         }
@@ -26,6 +27,7 @@ export function oneOf(chars: string): Parser<string> {
       if (charset.includes(char)) {
         return {
           isOk: true,
+          span: [pos, nextPos] as Span,
           pos: nextPos,
           value: char
         }
@@ -33,6 +35,7 @@ export function oneOf(chars: string): Parser<string> {
 
       return {
         isOk: false,
+        span: [pos, pos] as Span,
         pos,
         expected: `one of: ${charset.join(', ')}`
       }

--- a/src/parsers/regexp.ts
+++ b/src/parsers/regexp.ts
@@ -1,4 +1,4 @@
-import type { Parser, Span } from '@types'
+import type { Parser } from '@types'
 
 /**
  * Parses a string that matches a provided `re` regular expression. Returns the matched string, or
@@ -34,7 +34,7 @@ export function regexp(rs: RegExp, expected: string): Parser<string> {
 
         return {
           isOk: true,
-          span: [pos, index] as Span,
+          span: [pos, index],
           pos: index,
           value: match
         }
@@ -42,7 +42,7 @@ export function regexp(rs: RegExp, expected: string): Parser<string> {
         return {
           isOk: false,
           // TODO: Can this be improved? Zero-length span for this parser doesn't look helpful.
-          span: [pos, pos] as Span,
+          span: [pos, pos],
           pos,
           expected
         }

--- a/src/parsers/regexp.ts
+++ b/src/parsers/regexp.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 
 /**
  * Parses a string that matches a provided `re` regular expression. Returns the matched string, or
@@ -34,12 +34,15 @@ export function regexp(rs: RegExp, expected: string): Parser<string> {
 
         return {
           isOk: true,
+          span: [pos, index] as Span,
           pos: index,
           value: match
         }
       } else {
         return {
           isOk: false,
+          // TODO: Can this be improved? Zero-length span for this parser doesn't look helpful.
+          span: [pos, pos] as Span,
           pos,
           expected
         }

--- a/src/parsers/rest.ts
+++ b/src/parsers/rest.ts
@@ -1,15 +1,16 @@
-import type { Parser } from '@types'
+import type { Span, SucceedingParser } from '@types'
 
 /**
  * Simply returns the unparsed input as a string. Never fails.
  *
  * @returns Rest of the input as a string
  */
-export function rest(): Parser<string> {
+export function rest(): SucceedingParser<string> {
   return {
     parse(input, pos) {
       return {
         isOk: true,
+        span: [pos, input.length] as Span,
         pos: input.length,
         value: input.substring(pos)
       }

--- a/src/parsers/rest.ts
+++ b/src/parsers/rest.ts
@@ -1,4 +1,4 @@
-import type { Span, SucceedingParser } from '@types'
+import type { SucceedingParser } from '@types'
 
 /**
  * Simply returns the unparsed input as a string. Never fails.
@@ -10,7 +10,7 @@ export function rest(): SucceedingParser<string> {
     parse(input, pos) {
       return {
         isOk: true,
-        span: [pos, input.length] as Span,
+        span: [pos, input.length],
         pos: input.length,
         value: input.substring(pos)
       }

--- a/src/parsers/string.ts
+++ b/src/parsers/string.ts
@@ -13,7 +13,7 @@ export function string(match: string): Parser<string> {
     parse(input, pos) {
       const nextPos = Math.min(pos + match.length, input.length)
       const slice = input.substring(pos, nextPos)
-      const span = [pos, nextPos] as Span
+      const span: Span = [pos, nextPos]
 
       switch (slice === match) {
         case true: {
@@ -50,7 +50,7 @@ export function ustring(match: string): Parser<string> {
     parse(input, pos) {
       const nextPos = Math.min(pos + size(match), input.length)
       const slice = input.substring(pos, nextPos)
-      const span = [pos, nextPos] as Span
+      const span: Span = [pos, nextPos]
 
       switch (slice === match) {
         case true: {

--- a/src/parsers/string.ts
+++ b/src/parsers/string.ts
@@ -1,4 +1,4 @@
-import type { Parser } from '@types'
+import type { Parser, Span } from '@types'
 import { size } from '@utils/unicode'
 
 /**
@@ -13,11 +13,13 @@ export function string(match: string): Parser<string> {
     parse(input, pos) {
       const nextPos = Math.min(pos + match.length, input.length)
       const slice = input.substring(pos, nextPos)
+      const span = [pos, nextPos] as Span
 
       switch (slice === match) {
         case true: {
           return {
             isOk: true,
+            span,
             pos: nextPos,
             value: match
           }
@@ -26,6 +28,7 @@ export function string(match: string): Parser<string> {
         case false: {
           return {
             isOk: false,
+            span,
             pos: nextPos,
             expected: match
           }
@@ -47,11 +50,13 @@ export function ustring(match: string): Parser<string> {
     parse(input, pos) {
       const nextPos = Math.min(pos + size(match), input.length)
       const slice = input.substring(pos, nextPos)
+      const span = [pos, nextPos] as Span
 
       switch (slice === match) {
         case true: {
           return {
             isOk: true,
+            span,
             pos: nextPos,
             value: match
           }
@@ -60,6 +65,7 @@ export function ustring(match: string): Parser<string> {
         case false: {
           return {
             isOk: false,
+            span,
             pos: nextPos,
             expected: match
           }

--- a/src/parsers/tryRun.ts
+++ b/src/parsers/tryRun.ts
@@ -1,4 +1,4 @@
-import type { Failure, Parser, Success } from '@types'
+import type { Failure, Parser, Span, Success } from '@types'
 
 /** @internal */
 interface Runnable<T> {
@@ -10,10 +10,14 @@ type ErrorResult = Omit<Failure, 'isOk'>
 
 export class ParserError extends Error {
   readonly name = 'ParserError'
+
+  readonly span: Span
   readonly pos: number
 
   constructor(res: ErrorResult) {
     super(res.expected)
+
+    this.span = res.span
     this.pos = res.pos
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,14 @@
+/** Represents some range in the source input we are parsing or parsed. */
+export type Span = [start: number, end: number]
+
 /** Parsers of this type always succeed, e.g. `many` and `sepBy`. */
-export interface SafeParser<T> {
+export interface SucceedingParser<T> {
   parse(input: string, pos: number): Success<T>
+}
+
+/** Parsers of this type always fail. */
+export interface FailingParser {
+  parse(input: string, pos: number): Failure
 }
 
 /** Parsers of this type may fail. */
@@ -9,11 +17,12 @@ export interface UnsafeParser<T> {
 }
 
 /** Parser interface that all parsers and combinators consume and resolve to. */
-export type Parser<T> = SafeParser<T> | UnsafeParser<T>
+export type Parser<T> = FailingParser | SucceedingParser<T> | UnsafeParser<T>
 
 /** Represents failed execution. */
 export type Failure = {
   readonly isOk: false
+  readonly span: Span
   readonly pos: number
   readonly expected: string
 }
@@ -21,6 +30,7 @@ export type Failure = {
 /** Represents successful execution. */
 export type Success<T> = {
   readonly isOk: true
+  readonly span: Span
   readonly pos: number
   readonly value: T
 }
@@ -52,6 +62,9 @@ export type ToTuple<T> = T extends [Parser<infer Head>, ...infer Tail]
  * ```ts
  * type U = [Parser<string>, Parser<number>, Parser<boolean>]
  * type R = ToUnion<U> // type R = string | number | boolean
+ *
+ * type U = Array<Parser<number>>
+ * type R = ToUnion<U> // type R = number
  * ```
  */
 export type ToUnion<T> = T extends Array<Parser<infer Inner>>


### PR DESCRIPTION
This PR.

- Adds spans for all parsers and combinators that explicitly return results.
- Contains some minor improvements here and there.

Closes #34