### PR TITLE
fix(combinators/sepBy): do not mutate position on no match

### DIFF
--- a/src/__tests__/combinators/sepBy.spec.ts
+++ b/src/__tests__/combinators/sepBy.spec.ts
@@ -1,4 +1,4 @@
-import { sepBy, sepBy1 } from '@combinators'
+import { sepBy, sepBy1, sequence } from '@combinators'
 import { string } from '@parsers'
 import { run, result, should, describe, it } from '@testing'
 
@@ -23,6 +23,14 @@ describe('sepBy', () => {
     const parser = sepBy(string('hello'), string('?'))
     const actual = run(parser, 'bye?bye?')
     const expected = result(true, [])
+
+    should.matchState(actual, expected)
+  })
+
+  it('should successfully continue if nothing matched', () => {
+    const parser = sequence(sepBy(string('hello'), string('?')), sepBy(string('bye'), string('?')))
+    const actual = run(parser, 'bye?bye?')
+    const expected = result(true, [[], ['bye', 'bye']])
 
     should.matchState(actual, expected)
   })

--- a/src/combinators/sepBy.ts
+++ b/src/combinators/sepBy.ts
@@ -37,8 +37,8 @@ export function sepBy<T, S>(parser: Parser<T>, sep: Parser<S>): Parser<Array<T>>
 
       return {
         isOk: true,
-        span: [pos, resultP.pos],
-        pos: resultP.pos,
+        span: [pos, pos],
+        pos,
         value: []
       }
     }


### PR DESCRIPTION
This fix is kindly provided by @gilbert. Thank you for your contribution!

Closes #77.