### PR TITLE
Improve editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,17 @@
 # Stop .editorconfig files search on current file
 root = true
 
-# Unix-style newlines with a newline ending every file
-[*]
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-# Indentation override
 [*]
 indent_style = space
 indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 2000
+block_comment_start = /*
+block_comment = *
+block_comment_end = */
+
+[src/**]
+max_line_length = 120


### PR DESCRIPTION
- add all keys https://spec.editorconfig.org/#supported-pairs
- repository can be checked with https://github.com/greut/eclint

Only `src/__tests__/utils/unicode.data.ts` has 120+ long lines.
Maybe TypeScript has a feature to break long lines.

