### PR TITLE
fix: deferred parsers should throw if not initialized

### DIFF
--- a/docs/docs/content/parsers/defer.md
+++ b/docs/docs/content/parsers/defer.md
@@ -18,7 +18,7 @@ function defer<T>(): Deferred<T>
 
 ## Description
 
-`defer` is a special parser that has an additional `with` method, which should be used to define the parser. This parser is tailored for creating mutually recursive parsers.
+`defer` is a special parser that has an additional `with` method, which must be used to define the parser, before it is called. This parser is tailored for creating mutually recursive parsers.
 
 ## Example
 

--- a/src/__tests__/core/run.spec.ts
+++ b/src/__tests__/core/run.spec.ts
@@ -21,7 +21,11 @@ describe('run', () => {
     should.matchState(actual, expected)
   })
 
-  it('should throw if given a non-initialized deferred parser', () => {
-    testFailure('deferred', defer<string>())
+  it('should throw if given a parser that throws', () => {
+    const parser = defer<string>()
+
+    should.throwError(() => {
+      run(parser).with('')
+    }, new Error('Deferred parser was not initialized'))
   })
 })

--- a/src/__tests__/core/tryRun.spec.ts
+++ b/src/__tests__/core/tryRun.spec.ts
@@ -1,5 +1,5 @@
-import { defer, string, tryRun, ParserError } from '@parsers'
-import { describe, result, should, testFailure, it } from '@testing'
+import { defer, string, tryRun, ParserError, run } from '@parsers'
+import { describe, result, should, it } from '@testing'
 
 describe('tryRun', () => {
   it('should succeed if given a succeeding parser', () => {
@@ -10,7 +10,7 @@ describe('tryRun', () => {
     should.matchState(actual, expected)
   })
 
-  it('should fail if given a failing parser', () => {
+  it('should throw if given a failing parser', () => {
     const deferred = defer<string>()
 
     deferred.with(string('deferred'))
@@ -21,7 +21,11 @@ describe('tryRun', () => {
     should.throwError(actual, expected)
   })
 
-  it('should throw if given a non-initialized deferred parser', () => {
-    testFailure('deferred', defer<string>())
+  it('should throw if given a parser that throws', () => {
+    const parser = defer<string>()
+
+    should.throwError(() => {
+      run(parser).with('')
+    }, new Error('Deferred parser was not initialized'))
   })
 })

--- a/src/__tests__/parsers/defer.spec.ts
+++ b/src/__tests__/parsers/defer.spec.ts
@@ -1,8 +1,8 @@
 import { string, defer } from '@parsers'
-import { run, result, should, testFailure, describe, it } from '@testing'
+import { run, result, should, describe, it } from '@testing'
 
 describe('defer', () => {
-  it('should succeed if the deferred parser is not set', () => {
+  it('should succeed if the deferred parser succeeds', () => {
     const deferred = defer<string>()
 
     deferred.with(string('deferred'))
@@ -11,10 +11,6 @@ describe('defer', () => {
     const expected = result(true, 'deferred')
 
     should.matchState(actual, expected)
-  })
-
-  it('should throw if the deferred parser is not set', () => {
-    testFailure('deferred', defer<string>())
   })
 
   it('should fail if the deferred parser fails', () => {
@@ -26,5 +22,13 @@ describe('defer', () => {
     const expected = result(false, 'deferred')
 
     should.matchState(actual, expected)
+  })
+
+  it('should throw if the deferred parser is not set', () => {
+    const parser = defer<string>()
+
+    should.throwError(() => {
+      run(parser, '')
+    }, new Error('Deferred parser was not initialized'))
   })
 })

--- a/src/parsers/defer.ts
+++ b/src/parsers/defer.ts
@@ -69,12 +69,7 @@ export function defer<T>(): Deferred<T> {
         return deferred.parse(input, pos)
       }
 
-      return {
-        isOk: false,
-        span: [pos, pos],
-        pos,
-        expected: `Deferred parser wasn't initialized.`
-      }
+      throw new Error('Deferred parser was not initialized')
     }
   }
 }


### PR DESCRIPTION
Per #84 `defer` now throws an error if not initialized.

Documentation was updated as well.

Test for `run` and `tryRun` were also updated to reflect the change - and I generalized their descriptions, since their behavior with regards to error handling isn't specific to `defer`.
